### PR TITLE
fix(rivet+rivetc): fix `defer`/`errdefer` invalid execution

### DIFF
--- a/.github/workflows/self_host.yml
+++ b/.github/workflows/self_host.yml
@@ -1,4 +1,4 @@
-name: Self-hosted compiler
+name: Self-hosted Compiler
 
 on:
   push:

--- a/.github/workflows/self_host_nightly.yml
+++ b/.github/workflows/self_host_nightly.yml
@@ -1,4 +1,4 @@
-name: Self-hosted Compiler Nightly Build
+name: Self-hosted Compiler - Nightly Build
 
 on:
   push:

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -828,7 +828,7 @@ class ReturnExpr:
         self.has_expr = has_expr
         self.pos = pos
         self.typ = None
-        self.scope = None
+        self.scope = scope
 
     def __repr__(self):
         if self.has_expr:
@@ -843,7 +843,7 @@ class ThrowExpr:
         self.expr = expr
         self.pos = pos
         self.typ = None
-        self.scope = None
+        self.scope = scope
 
     def __repr__(self):
         return f"throw {self.expr}"

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -646,7 +646,7 @@ class IndexExpr:
 
 class CallExpr:
     def __init__(
-        self, left, args, has_spread_expr, spread_expr, err_handler, pos
+        self, left, args, has_spread_expr, spread_expr, err_handler, pos, scope=None
     ):
         self.sym = None
         self.left = left
@@ -660,6 +660,7 @@ class CallExpr:
         self.enum_variant_sym = None
         self.pos = pos
         self.typ = None
+        self.scope = scope
 
     def has_named_args(self):
         for arg in self.args:

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -810,10 +810,11 @@ class SelectorExpr:
         return self.__repr__()
 
 class BranchExpr:
-    def __init__(self, op, pos):
+    def __init__(self, op, pos, scope=None):
         self.op = op
         self.pos = pos
         self.typ = None
+        self.scope=scope
 
     def __repr__(self):
         return str(self.op)

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -301,6 +301,7 @@ class TestDecl:
         self.stmts = stmts
         self.scope = scope
         self.pos = pos
+        self.defer_stmts = []
 
 # ------ Statements --------
 class StaticDeclStmt:

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -332,11 +332,12 @@ class ForStmt:
         self.pos = pos
 
 class DeferStmt:
-    def __init__(self, expr, is_errdefer, pos):
+    def __init__(self, expr, is_errdefer, pos, scope = None):
         self.expr = expr
         self.is_errdefer = is_errdefer
         self.flag_var = ""
         self.pos = pos
+        self.scope = scope
 
 class ExprStmt:
     def __init__(self, expr, pos):
@@ -820,25 +821,27 @@ class BranchExpr:
         return self.__repr__()
 
 class ReturnExpr:
-    def __init__(self, expr, has_expr, pos):
+    def __init__(self, expr, has_expr, pos, scope = None):
         self.expr = expr
         self.has_expr = has_expr
         self.pos = pos
         self.typ = None
+        self.scope = None
 
     def __repr__(self):
-        if not self.has_expr:
-            return "return"
-        return f"return {self.expr}"
+        if self.has_expr:
+            return f"return {self.expr}"
+        return "return"
 
     def __str__(self):
         return self.__repr__()
 
 class ThrowExpr:
-    def __init__(self, expr, pos):
+    def __init__(self, expr, pos, scope = None):
         self.expr = expr
         self.pos = pos
         self.typ = None
+        self.scope = None
 
     def __repr__(self):
         return f"throw {self.expr}"

--- a/rivetc/src/checker.py
+++ b/rivetc/src/checker.py
@@ -200,6 +200,8 @@ class Checker:
             self.cur_fn = None
             self.inside_test = True
             self.check_stmts(decl.stmts)
+            decl.defer_stmts = self.defer_stmts
+            self.defer_stmts = []
             self.inside_test = False
             self.cur_fn = old_cur_fn
             self.check_mut_vars(decl.scope)

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -432,7 +432,7 @@ class Codegen:
             self.cur_fn_ret_typ = decl.ret_typ
             self.gen_defer_stmt_vars(decl.defer_stmts)
             self.gen_stmts(decl.stmts)
-            self.gen_defer_stmts()
+            self.gen_defer_stmts(scope=decl.scope)
             if str(fn_decl.ret_typ) == "_R7Result__R4void":
                 self.cur_fn.add_ret(self.result_void(decl.ret_typ))
             elif str(fn_decl.ret_typ) != "void" and not (

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -1066,9 +1066,12 @@ class Codegen:
                 else:
                     assert False, expr
         elif isinstance(expr, ast.Block):
+            old_cfd = self.cur_fn_defer_stmts
+            self.cur_fn_defer_stmts = []
             self.gen_defer_stmt_vars(expr.defer_stmts)
             self.gen_stmts(expr.stmts)
             self.gen_defer_stmts()
+            self.cur_fn_defer_stmts = old_cfd
             if expr.is_expr:
                 return self.gen_expr_with_cast(expr.typ, expr.expr)
             return ir.Skip()

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -430,12 +430,6 @@ class Codegen:
             self.cur_fn.arr_ret_struct = arr_ret_struct
             self.cur_fn_is_main = decl.is_main
             self.cur_fn_ret_typ = decl.ret_typ
-            for defer_stmt in decl.defer_stmts:
-                defer_stmt.flag_var = self.cur_fn.local_name()
-                self.cur_fn.alloca(
-                    ir.Ident(ir.BOOL_T, defer_stmt.flag_var),
-                    ir.IntLit(ir.BOOL_T, "0")
-                )
             self.gen_defer_stmt_vars(decl.defer_stmts)
             self.gen_stmts(decl.stmts)
             self.gen_defer_stmts()

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -432,8 +432,9 @@ class Codegen:
             self.cur_fn_ret_typ = decl.ret_typ
             self.gen_defer_stmt_vars(decl.defer_stmts)
             self.gen_stmts(decl.stmts)
-            if str(fn_decl.ret_typ) == "_R7Result__R4void":
+            if str(fn_decl.ret_typ) == "void" or str(fn_decl.ret_typ) == "_R7Result__R4void":
                 self.gen_defer_stmts(scope=decl.scope)
+            if str(fn_decl.ret_typ) == "_R7Result__R4void":
                 self.cur_fn.add_ret(self.result_void(decl.ret_typ))
             elif str(fn_decl.ret_typ) != "void" and not (
                 len(fn_decl.instrs) > 0

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -2394,6 +2394,8 @@ class Codegen:
                 )
                 self.cur_fn.add_ret(expr_)
                 return ir.Skip()
+            else:
+                assert False
         else:
             if expr is None:
                 raise Exception(expr)
@@ -2459,7 +2461,9 @@ class Codegen:
     def gen_defer_stmts(self, gen_errdefer = False, last_ret_was_err = None, scope=None, is_ret=False):
         for i in range(len(self.cur_fn_defer_stmts) - 1, -1, -1):
             defer_stmt = self.cur_fn_defer_stmts[i]
-            if (is_ret and not (scope.start >= defer_stmt.scope.start)) or (scope.start != defer_stmt.scope.start):
+            if not (
+                (is_ret and scope.start >= defer_stmt.scope.start) or (scope.start == defer_stmt.scope.start)
+            ):
                 continue
             if defer_stmt.is_errdefer and not gen_errdefer:
                 continue

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -2466,9 +2466,8 @@ class Codegen:
     def gen_defer_stmts(self, gen_errdefer = False, last_ret_was_err = None, scope=None, is_ret=False):
         for i in range(len(self.cur_fn_defer_stmts) - 1, -1, -1):
             defer_stmt = self.cur_fn_defer_stmts[i]
-            if sc := scope:
-                if (is_ret and not (sc.start >= defer_stmt.scope.start)) or (sc.start != defer_stmt.scope.start):
-                    continue
+            if (is_ret and not (scope.start <= defer_stmt.scope.start)) or (scope.start != defer_stmt.scope.start):
+                continue
             if defer_stmt.is_errdefer and not gen_errdefer:
                 continue
             defer_start = self.cur_fn.local_name()

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -432,11 +432,12 @@ class Codegen:
             self.cur_fn_ret_typ = decl.ret_typ
             self.gen_defer_stmt_vars(decl.defer_stmts)
             self.gen_stmts(decl.stmts)
-            if str(fn_decl.ret_typ) == "void" or str(fn_decl.ret_typ) == "_R7Result__R4void":
+            fn_dec_ret_type_str = str(fn_decl.ret_typ)
+            if fn_dec_ret_type_str == "void" or fn_dec_ret_type_str == "_R6Result_R4void":
                 self.gen_defer_stmts(scope=decl.scope)
-            if str(fn_decl.ret_typ) == "_R7Result__R4void":
+            if fn_dec_ret_type_str == "_R6Result_R4void":
                 self.cur_fn.add_ret(self.result_void(decl.ret_typ))
-            elif str(fn_decl.ret_typ) != "void" and not (
+            elif fn_dec_ret_type_str != "void" and not (
                 len(fn_decl.instrs) > 0
                 and isinstance(fn_decl.instrs[-1], ir.Inst)
                 and fn_decl.instrs[-1].kind == ir.InstKind.Ret

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -432,8 +432,8 @@ class Codegen:
             self.cur_fn_ret_typ = decl.ret_typ
             self.gen_defer_stmt_vars(decl.defer_stmts)
             self.gen_stmts(decl.stmts)
-            self.gen_defer_stmts(scope=decl.scope)
             if str(fn_decl.ret_typ) == "_R7Result__R4void":
+                self.gen_defer_stmts(scope=decl.scope)
                 self.cur_fn.add_ret(self.result_void(decl.ret_typ))
             elif str(fn_decl.ret_typ) != "void" and not (
                 len(fn_decl.instrs) > 0

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -458,7 +458,7 @@ class Codegen:
                     [ir.Ident(ir.TEST_T.ptr(), "test")], False, ir.VOID_T, False
                 )
                 self.cur_fn = test_fn
-                self.gen_defer_stmt_var(decl.defer_stmts)
+                self.gen_defer_stmt_vars(decl.defer_stmts)
                 self.gen_stmts(decl.stmts)
                 self.gen_defer_stmts()
                 self.generated_tests.append(TestInfo(test_name, test_func))

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -460,7 +460,7 @@ class Codegen:
                 self.cur_fn = test_fn
                 self.gen_defer_stmt_vars(decl.defer_stmts)
                 self.gen_stmts(decl.stmts)
-                self.gen_defer_stmts()
+                self.gen_defer_stmts(scope=decl.scope)
                 self.generated_tests.append(TestInfo(test_name, test_func))
                 self.out_rir.decls.append(test_fn)
                 self.inside_test = False

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -2466,7 +2466,7 @@ class Codegen:
     def gen_defer_stmts(self, gen_errdefer = False, last_ret_was_err = None, scope=None, is_ret=False):
         for i in range(len(self.cur_fn_defer_stmts) - 1, -1, -1):
             defer_stmt = self.cur_fn_defer_stmts[i]
-            if (is_ret and not (scope.start <= defer_stmt.scope.start)) or (scope.start != defer_stmt.scope.start):
+            if (is_ret and not (scope.start >= defer_stmt.scope.start)) or (scope.start != defer_stmt.scope.start):
                 continue
             if defer_stmt.is_errdefer and not gen_errdefer:
                 continue

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -2466,9 +2466,7 @@ class Codegen:
         for i in range(len(self.cur_fn_defer_stmts) - 1, -1, -1):
             defer_stmt = self.cur_fn_defer_stmts[i]
             if sc := scope:
-                if is_ret and sc.start < defer_stmt.scope.start:
-                    continue
-                if sc.start != defer_stmt.scope.start:
+                if (is_ret and not (sc.start >= defer_stmt.scope.start)) or (sc.start != defer_stmt.scope.start):
                     continue
             if defer_stmt.is_errdefer and not gen_errdefer:
                 continue

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -2352,7 +2352,7 @@ class Codegen:
                         ir.Name("result")
                     ), ir.IntLit(ir.UINT8_T, "1")
                 )
-                self.gen_defer_stmts()
+                #self.gen_defer_stmts()
                 self.cur_fn.add_ret_void()
             elif expr.has_expr:
                 is_array = self.cur_fn_ret_typ.symbol().kind == TypeKind.Array
@@ -2375,13 +2375,13 @@ class Codegen:
                     expr_ = tmp
                 if wrap_result:
                     expr_ = self.result_value(self.cur_fn_ret_typ, expr_)
-                self.gen_defer_stmts()
+                #self.gen_defer_stmts()
                 self.cur_fn.add_ret(expr_)
             elif wrap_result:
-                self.gen_defer_stmts()
+                #self.gen_defer_stmts()
                 self.cur_fn.add_ret(self.result_void(self.cur_fn_ret_typ))
             else:
-                self.gen_defer_stmts()
+                #self.gen_defer_stmts()
                 self.cur_fn.add_ret_void()
             return ir.Skip()
         elif isinstance(expr, ast.ThrowExpr):

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -2339,6 +2339,7 @@ class Codegen:
                         self.gen_expr(self.while_continue_expr)
                 self.cur_fn.add_br(self.loop_entry_label)
             else:
+                self.gen_defer_stmts()
                 self.cur_fn.add_br(self.loop_exit_label)
             return ir.Skip()
         elif isinstance(expr, ast.ReturnExpr):
@@ -2374,10 +2375,7 @@ class Codegen:
                     expr_ = tmp
                 if wrap_result:
                     expr_ = self.result_value(self.cur_fn_ret_typ, expr_)
-                self.gen_defer_stmts(
-                    wrap_result,
-                    ir.Selector(ir.BOOL_T, expr_, ir.Name("is_err"))
-                )
+                self.gen_defer_stmts()
                 self.cur_fn.add_ret(expr_)
             elif wrap_result:
                 self.gen_defer_stmts()

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -458,7 +458,9 @@ class Codegen:
                     [ir.Ident(ir.TEST_T.ptr(), "test")], False, ir.VOID_T, False
                 )
                 self.cur_fn = test_fn
+                self.gen_defer_stmt_var(decl.defer_stmts)
                 self.gen_stmts(decl.stmts)
+                self.gen_defer_stmts()
                 self.generated_tests.append(TestInfo(test_name, test_func))
                 self.out_rir.decls.append(test_fn)
                 self.inside_test = False

--- a/rivetc/src/codegen/c.py
+++ b/rivetc/src/codegen/c.py
@@ -1,4 +1,4 @@
-Ji# Copyright (C) 2023 The Rivet Developers. All rights reserved.
+# Copyright (C) 2023 The Rivet Developers. All rights reserved.
 # Use of this source code is governed by an MIT license that can
 # be found in the LICENSE file.
 

--- a/rivetc/src/codegen/c.py
+++ b/rivetc/src/codegen/c.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 The Rivet Developers. All rights reserved.
+Ji# Copyright (C) 2023 The Rivet Developers. All rights reserved.
 # Use of this source code is governed by an MIT license that can
 # be found in the LICENSE file.
 
@@ -238,7 +238,7 @@ class CGen:
             elif isinstance(inst, ir.Comment):
                 self.writeln(f"/* {inst.text} */")
             elif isinstance(inst, ir.Label):
-                self.writeln(f"{inst.label}: {{}}")
+                self.writeln(f"{inst.label}: ;")
             elif isinstance(inst, ir.Inst):
                 self.gen_inst(inst)
                 if inst.kind == InstKind.DbgStmtLine:

--- a/rivetc/src/parser.py
+++ b/rivetc/src/parser.py
@@ -814,7 +814,7 @@ class Parser:
             op = self.tok.kind
             pos = self.tok.pos
             self.next()
-            expr = ast.BranchExpr(op, pos)
+            expr = ast.BranchExpr(op, pos, self.scope)
         elif self.accept(Kind.KwReturn):
             pos = self.prev_tok.pos
             has_expr = self.tok.kind not in (

--- a/rivetc/src/parser.py
+++ b/rivetc/src/parser.py
@@ -962,7 +962,7 @@ class Parser:
                     ast.CallErrorHandler(
                         is_propagate, varname, err_expr, has_err_expr,
                         varname_pos, self.scope, err_handler_pos
-                    ), expr.pos
+                    ), expr.pos, self.scope
                 )
             elif self.accept(Kind.Lbracket):
                 index = self.empty_expr()

--- a/rivetc/src/parser.py
+++ b/rivetc/src/parser.py
@@ -607,7 +607,7 @@ class Parser:
             expr = self.parse_expr()
             if expr.__class__ not in (ast.IfExpr, ast.MatchExpr, ast.Block):
                 self.expect(Kind.Semicolon)
-            return ast.DeferStmt(expr, is_errdefer, pos)
+            return ast.DeferStmt(expr, is_errdefer, pos, self.scope)
         elif (
             self.tok.kind in (Kind.Lparen, Kind.KwMut, Kind.Name) and
             self.peek_tok.kind not in (Kind.Dot, Kind.Lbracket, Kind.Lparen)
@@ -824,10 +824,10 @@ class Parser:
                 expr = self.parse_expr()
             else:
                 expr = self.empty_expr()
-            expr = ast.ReturnExpr(expr, has_expr, pos)
+            expr = ast.ReturnExpr(expr, has_expr, pos, self.scope)
         elif self.accept(Kind.KwThrow):
             pos = self.prev_tok.pos
-            expr = ast.ThrowExpr(self.parse_expr(), pos)
+            expr = ast.ThrowExpr(self.parse_expr(), pos, self.scope)
         elif self.tok.kind == Kind.KwIf:
             expr = self.parse_if_expr()
         elif self.accept(Kind.KwMatch):

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -59,13 +59,15 @@ func test_errdefer(mut err_defer: ErrDefer, err: bool) -> ! {
         throw MyError();
     }
 }
-
+import std/console;
 test "`errdefer` statement" {
     mut err_defer := ErrDefer(i: 0);
+
     test_errdefer(err_defer, false) catch { };
     @assert(err_defer.i == 1);
 
     test_errdefer(err_defer, true) catch { };
+console.writeln("i: {}",err_defer.i);
     @assert(err_defer.i == 3);
 }
 

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -13,7 +13,7 @@ test "`defer` basic" {
     a = 5;
     @assert(a == 5);
 }
-
+import std/console;
 func test_defer(five: bool, early_return: bool := false) -> int32 {
     mut a := 1;
     if five {
@@ -27,6 +27,7 @@ func test_defer(five: bool, early_return: bool := false) -> int32 {
 }
 
 test "`defer` from a call" {
+    console.writeln(test_defer(false));
     @assert(test_defer(false) == 1);
     @assert(test_defer(true) == 5);
     @assert(test_defer(true, true) == 7);

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -26,7 +26,7 @@ test "`defer` basic 2" {
 test "defer` basic 3" {
     mut sum := 0;
     defer @assert(sum == 3);
-    defer sum + = 1;
+    defer sum += 1;
     defer sum += 2;
     if false {
         // should not be executed

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -17,7 +17,7 @@ import std/console;
 func test_defer(five: bool, early_return: bool := false) -> int {
     mut a := 1;
     if five {
-        consolé.writeln("if five");
+        console.writeln("if five");
         defer a = 5;
         if early_return {
             //defer a += 2;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -17,6 +17,7 @@ import std/console;
 func test_defer(five: bool, early_return: bool := false) -> int {
     mut a := 1;
     if five {
+        consolé.writeln("if five");
         defer a = 5;
         if early_return {
             //defer a += 2;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -24,7 +24,7 @@ test "`defer` basic 2" {
 }
 
 
-func test_call() -> int {
+func test_defer_call() -> int {
     mut a := 1;
 
     {

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -25,7 +25,7 @@ test "`defer` basic 2" {
 
 test "defer` basic 3" {
     mut sum := 0;
-    defer @assert(sum == 3);
+    defer @assert(sum == 4);
     defer sum += 1;
     defer sum += 2;
     if false {

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -27,7 +27,7 @@ func test_defer(five: bool, early_return: bool := false) -> int32 {
 }
 
 test "`defer` from a call" {
-    console.writeln(test_defer(false));
+    console.writeln("{}", test_defer(false));
     @assert(test_defer(false) == 1);
     @assert(test_defer(true) == 5);
     @assert(test_defer(true, true) == 7);

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -28,6 +28,7 @@ func test_defer(five: bool, early_return: bool := false) -> int {
     mut a := 0;
     if five {
         console.writeln("if five");
+        defer console.writeln("a += 5 {}", five);
         defer a += 5;
         if early_return {
             defer a += 2;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -27,8 +27,8 @@ import std/console;
 func test_defer(five: bool, early_return: bool := false) -> int {
     mut a := 0;
     if five {
-        console.writeln("if five");
-        defer console.writeln("a += 5 {}", five);
+        console.ewriteln("if five");
+        defer console.ewriteln("a += 5 {}", five);
         defer a += 5;
         if early_return {
             defer a += 2;
@@ -39,7 +39,6 @@ func test_defer(five: bool, early_return: bool := false) -> int {
 }
 
 test "`defer` from a call" {
-    console.writeln("{}", test_defer(false));
     @assert(test_defer(false) == 0);
     @assert(test_defer(true) == 5);
     @assert(test_defer(true, true) == 7);

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -23,6 +23,16 @@ test "`defer` basic 2" {
     @assert(sum == 0);
 }
 
+test "defer` basic 3" {
+    mut sum := 0;
+    defer @assert(sum == 3);
+    defer sum + = 1;
+    defer sum += 2;
+    if false {
+        // should not be executed
+        defer sum += 1;
+    }
+}
 
 func test_defer_call() -> int {
     mut a := 1;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -17,7 +17,7 @@ test "`defer` basic" {
 test "`defer` basic 2" {
     i := 10;
     j := 30;
-    muy sum := 0;
+    mut sum := 0;
     defer @assert(sum == 30);
     defer sum = i + j;
     @assert(sum == 0);

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -28,7 +28,7 @@ test "defer` basic 3" {
     defer @assert(sum == 3);
     defer sum += 1;
     defer sum += 2;
-    if true {
+    if false {
         // should not be executed
         defer sum += 1;
     }

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -14,7 +14,7 @@ test "`defer` basic" {
     @assert(a == 5);
 }
 import std/console;
-func test_defer(five: bool, early_return: bool := false) -> int32 {
+func test_defer(five: bool, early_return: bool := false) -> int {
     mut a := 1;
     if five {
         defer a = 5;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -66,7 +66,7 @@ test "`errdefer` statement" {
     @assert(err_defer.i == 1);
 
     test_errdefer(err_defer, true) catch { };
-    @assert(err_defer.i == 4);
+    @assert(err_defer.i == 3);
 }
 
 func throw_error() -> ! {

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -59,15 +59,15 @@ func test_errdefer(mut err_defer: ErrDefer, err: bool) -> ! {
         throw MyError();
     }
 }
-import std/console;
+
 test "`errdefer` statement" {
     mut err_defer := ErrDefer(i: 0);
 
     test_errdefer(err_defer, false) catch { };
     @assert(err_defer.i == 1);
 
+    err_defer.i = 0;
     test_errdefer(err_defer, true) catch { };
-console.writeln("i: {}",err_defer.i);
     @assert(err_defer.i == 3);
 }
 

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -25,7 +25,7 @@ test "`defer` basic 2" {
 
 test "defer` basic 3" {
     mut sum := 0;
-    defer @assert(sum == 4);
+    defer @assert(sum == 3);
     defer sum += 1;
     defer sum += 2;
     if false {

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -23,25 +23,22 @@ test "`defer` basic 2" {
     @assert(sum == 0);
 }
 
-import std/console;
-func test_defer(five: bool, early_return: bool := false) -> int {
-    mut a := 0;
-    if five {
-        console.ewriteln("if five");
-        defer console.ewriteln("a += 5 {}", five);
-        defer a += 5;
-        if early_return {
-            defer a += 2;
-            return a;
-        }
+
+func test_call() -> int {
+    mut a := 1;
+
+    {
+        defer a = 2;
+        a = 1;
     }
+    @assert(a == 2);
+
+    a = 5;
     return a;
 }
 
 test "`defer` from a call" {
-    @assert(test_defer(false) == 0);
-    @assert(test_defer(true) == 5);
-    @assert(test_defer(true, true) == 7);
+    @assert(test_defer_call() == 5);
 }
 
 func test_errdefer(mut err_defer: ErrDefer, err: bool) -> ! {

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -13,6 +13,16 @@ test "`defer` basic" {
     a = 5;
     @assert(a == 5);
 }
+
+test "`defer` basic 2" {
+    i := 10;
+    j := 30;
+    muy sum := 0;
+    defer @assert(sum == 30);
+    defer sum = i + j;
+    @assert(sum == 0);
+}
+
 import std/console;
 func test_defer(five: bool, early_return: bool := false) -> int {
     mut a := 1;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -25,12 +25,12 @@ test "`defer` basic 2" {
 
 import std/console;
 func test_defer(five: bool, early_return: bool := false) -> int {
-    mut a := 1;
+    mut a := 0;
     if five {
         console.writeln("if five");
-        defer a = 5;
+        defer a += 5;
         if early_return {
-            //defer a += 2;
+            defer a += 2;
             return a;
         }
     }
@@ -39,9 +39,9 @@ func test_defer(five: bool, early_return: bool := false) -> int {
 
 test "`defer` from a call" {
     console.writeln("{}", test_defer(false));
-    @assert(test_defer(false) == 1);
+    @assert(test_defer(false) == 0);
     @assert(test_defer(true) == 5);
-    @assert(test_defer(true, true) == 1);
+    @assert(test_defer(true, true) == 7);
 }
 
 func test_errdefer(mut err_defer: ErrDefer, err: bool) -> ! {

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -16,7 +16,7 @@ test "`defer` basic" {
 
 test "`defer` basic 2" {
     i := 10;
-    j := 30;
+    j := 20;
     mut sum := 0;
     defer @assert(sum == 30);
     defer sum = i + j;

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -28,7 +28,7 @@ test "defer` basic 3" {
     defer @assert(sum == 3);
     defer sum += 1;
     defer sum += 2;
-    if false {
+    if true {
         // should not be executed
         defer sum += 1;
     }

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -19,7 +19,7 @@ func test_defer(five: bool, early_return: bool := false) -> int32 {
     if five {
         defer a = 5;
         if early_return {
-            defer a += 2;
+            //defer a += 2;
             return a;
         }
     }

--- a/tests/valid/src/defer_stmt.ri
+++ b/tests/valid/src/defer_stmt.ri
@@ -31,7 +31,7 @@ test "`defer` from a call" {
     console.writeln("{}", test_defer(false));
     @assert(test_defer(false) == 1);
     @assert(test_defer(true) == 5);
-    @assert(test_defer(true, true) == 7);
+    @assert(test_defer(true, true) == 1);
 }
 
 func test_errdefer(mut err_defer: ErrDefer, err: bool) -> ! {

--- a/tests/valid/src/if_expr.ri
+++ b/tests/valid/src/if_expr.ri
@@ -13,3 +13,11 @@ test "`if` expression as statement" {
         @assert(false);
     }
 }
+
+test "`if` expression with false condition" {
+    mut x := 0;
+    if false {
+        x = 1;
+    }
+    @assert(x == 0);
+}


### PR DESCRIPTION
Fix invalid execution of `defer`/`errdefer`, as well as make some improvements to the compiler and tests.