### PR TITLE
feat(rivet+rivetc): support new syntax for initializing arrays

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -23,7 +23,6 @@
 - [ ] (Atomic) Reference-Counting for traits, tagged enums, strings, dynamic arrays and structs.
 - [ ] Better support for embedded structs.
 - [ ] `undefined` for uninitialized variables: `x: [5]uint8 := undefined;`.
-- [ ] Disallow empty array literal (`x := []; -> ERROR`).
 - [ ] Add `@is_flag_defined()` builtin function.
 - [ ] Generic support: `Struct<T> { f: T; }` => `Struct:<T>(f: @default(T))`.
 - [ ] Lambdas + Closures: `sum := |a: int32, b: int32| [my_inherited_var] a + b;`.
@@ -52,4 +51,3 @@
         console.writeln("executed in compile-time");
     }
     ```
-

--- a/lib/core/src/DynArray.ri
+++ b/lib/core/src/DynArray.ri
@@ -17,14 +17,28 @@ struct DynArray {
 
     #[unsafe; inline]
     func new_with_len(elem_size: uint, len: uint, cap: uint) -> Self {
-        return Self(mem_zeroed(cap * elem_size), elem_size, len, cap);
+        cap_ := if cap < len { len } else { cap };
+        return Self(mem_zeroed(cap_ * elem_size), elem_size, len, cap);
+    }
+
+    #[unsafe; inline]
+    func new_with_init(init: rawptr, elem_size: uint, len: uint, cap: uint) -> Self {
+        cap_ := if cap < len { len } else { cap };
+        dyn_array := Self(mem_alloc(cap_ * elem_size), elem_size, len, cap);
+        mut i: uint := 0;
+        while i < len : i += 1 {
+            unsafe {
+                dyn_array.raw_set(i, init);
+            }
+        }
+        return dyn_array;
     }
 
     #[unsafe]
     func from_array(arr: rawptr, elem_size: uint, len: uint) -> Self {
-        vec := Self(mem_zeroed(len * elem_size), elem_size, len, len);
-        mem_copy(vec.ptr, arr, len * elem_size);
-        return vec;
+        dyn_array := Self(mem_alloc(len * elem_size), elem_size, len, len);
+        mem_copy(dyn_array.ptr, arr, len * elem_size);
+        return dyn_array;
     }
 
     #[unsafe; inline]
@@ -42,6 +56,16 @@ struct DynArray {
             runtime_error("dynamic array index out of range (index: {}, len: {})", idx, self.len);
         }
         return unsafe { @ptr_add(@as([&]mut uint8, self.ptr), idx * self.elem_size) };
+    }
+
+    #[unsafe; inline]
+    func raw_set(self, idx: uint, val: rawptr) {
+        unsafe {
+            mem_copy(
+                @ptr_add(@as([&]mut uint8, self.ptr), self.elem_size * idx),
+                val, self.elem_size
+            );
+        }
     }
 
     func set(self, idx: uint, val: rawptr) {
@@ -181,9 +205,9 @@ struct DynArray {
         if size == 0 {
             size = 1;
         }
-        vec := Self(mem_zeroed(size), self.elem_size, self.len, self.cap);
-        mem_copy(vec.ptr, self.ptr, size);
-        return vec;
+        dyn_array := Self(mem_zeroed(size), self.elem_size, self.len, self.cap);
+        mem_copy(dyn_array.ptr, self.ptr, size);
+        return dyn_array;
     }
 
     func __drop__(self) {

--- a/lib/core/src/array.c.ri
+++ b/lib/core/src/array.c.ri
@@ -4,6 +4,15 @@
 
 import c/libc;
 
+func array_init_set(arr: rawptr, elem_size: uint, len: uint, value: rawptr) {
+    mut i: uint := 0;
+    while i < len : i += 1 {
+        unsafe {
+            mem_copy(@ptr_add(@as([&]mut uint8, arr), elem_size * i), value, elem_size);
+        }
+    }
+}
+
 func array_index(len: uint, idx: uint) {
     if idx >= len {
         runtime_error("array index out of range (index: {}, size: {})", idx, len);

--- a/lib/core/src/entry_point.ri
+++ b/lib/core/src/entry_point.ri
@@ -12,7 +12,7 @@ extern (Rivet) {
 
 func init_args(_argc: uint, _argv: [&][&]uint8) {
     unsafe {
-        ARGS = @dyn_array(string, _argc);
+        ARGS = []string(cap: _argc);
         mut i: uint := 0;
         while i < _argc : i += 1 {
             ARGS.push(string.from_raw(_argv[i]));

--- a/lib/core/src/process.c.ri
+++ b/lib/core/src/process.c.ri
@@ -6,7 +6,7 @@ import c/libc;
 
 /// Returns the path name of the executable that started the current process.
 pub func process_executable() -> !string {
-    res: [libc.MAX_PATH_LEN]uint8 := [];
+    res := [libc.MAX_PATH_LEN]uint8();
     count := unsafe {
         libc.readlink(c"/proc/self/exe", &res[0], libc.MAX_PATH_LEN)
     };
@@ -28,7 +28,7 @@ pub func process_set_cwd(path: string) -> ! {
 /// Returns the absolute path of the current working directory.
 pub func process_get_cwd() -> !string {
     unsafe {
-        buf: [libc.MAX_PATH_LEN]mut uint8 := [];
+        buf := [libc.MAX_PATH_LEN]mut uint8();
         if _ := libc.getcwd(&mut buf[0], libc.MAX_PATH_LEN) {
             return string.from_raw(&buf[0]).clone();
         }

--- a/lib/core/src/rune.ri
+++ b/lib/core/src/rune.ri
@@ -49,7 +49,7 @@ extend rune < Stringable {
     }
 
     pub func as_bytes(self) -> []uint8 {
-        res := @dyn_array(uint8, 5);
+        res := []uint8(cap: 5);
         res_v := @as(DynArray, res);
         res_v.len = utf32_decode_to_buffer(self, unsafe { @as([&]mut uint8, res_v.ptr) });
         return res;

--- a/lib/core/src/string.c.ri
+++ b/lib/core/src/string.c.ri
@@ -100,7 +100,7 @@ pub struct string < Stringable, Hashable, Throwable {
 
     /// Returns a string array of the string split by '\t' and ' '.
     pub func fields(self) -> []Self {
-        mut res := @dyn_array(Self);
+        mut res := []Self();
         mut word_start: uint := 0;
         mut word_len: uint := 0;
         mut is_in_word := false;
@@ -458,7 +458,7 @@ pub struct string < Stringable, Hashable, Throwable {
             return self;
         }
         mut idx: uint := 0;
-        mut idxs := @dyn_array(uint);
+        mut idxs := []uint();
         while {
             idx = self.index_after_of(rep, idx) ?? break;
             idxs.push(idx);
@@ -508,7 +508,7 @@ pub struct string < Stringable, Hashable, Throwable {
     /// Returns an array of all the UTF8 runes in the string `self` which is useful
     /// if you want random access to them.
     pub func as_runes(self) -> []rune {
-        mut runes := @dyn_array(rune, self.runes_count());
+        mut runes := []rune(cap: self.runes_count());
         mut i: uint := 0;
         while i < self.len : i += 1 {
             char_len := unsafe { self.ptr[i] }.len_utf8();
@@ -541,7 +541,7 @@ pub struct string < Stringable, Hashable, Throwable {
     /// remainder contains more `delim` substrings.
     pub func split(self, delim: Self, nth: uint := 0) -> []Self {
         mut i: uint := 0;
-        mut res := @dyn_array(Self);
+        mut res := []Self();
         match delim.len {
             0 -> {
                 i = 1;
@@ -601,7 +601,7 @@ pub struct string < Stringable, Hashable, Throwable {
     /// If the delimiter string is empty then `.split()` is used.
     pub func split_any(self, delim: Self) -> []Self {
         mut i: uint := 0;
-        mut res := @dyn_array(Self);
+        mut res := []Self();
         // check empty source string
         if self.len > 0 {
             // if empty delimiter string using default split
@@ -629,7 +629,7 @@ pub struct string < Stringable, Hashable, Throwable {
     /// NOTE: algorithm is "greedy", consuming '\r\n' as a single line ending with higher
     /// priority than '\r' and '\n' as multiple endings
     pub func split_into_lines(self) -> []Self {
-        mut res := @dyn_array(Self);
+        mut res := []Self();
         if self.len == 0 {
             return res;
         }

--- a/lib/core/tests/string_test.ri
+++ b/lib/core/tests/string_test.ri
@@ -56,7 +56,7 @@ test "string.runes_count()" {
 
 test "string.tokenize()" {
     mut iterator := "   abc def    ghi  ".tokenize(b' ');
-    mut res := @dyn_array(string, 3);
+    mut res := []string(cap: 3);
     while w := iterator.next() {
         res.push(w);
     }

--- a/lib/rivet/src/ast/CHeader.ri
+++ b/lib/rivet/src/ast/CHeader.ri
@@ -126,7 +126,7 @@ extend Table {
                 mut name := tokens.next()?;
                 define_value := tokens.rest();
                 has_value := define_value.len > 0;
-                mut args := @dyn_array(string);
+                mut args := []string();
                 mut is_macro := true;
                 if has_value {
                     if paren_idx := name.index_of_byte(b'(') {

--- a/lib/rivet/src/ast/CHeader.ri
+++ b/lib/rivet/src/ast/CHeader.ri
@@ -157,7 +157,7 @@ extend Table {
             lines := result.output.find_between(
                 "#include <...> search starts here:", "End of search list."
             ).split_into_lines();
-            mut paths := @dyn_array(string);
+            mut paths := []string();
             for line in lines {
                 if line.is_empty() {
                     continue;

--- a/lib/rivet/src/ast/Decl.ri
+++ b/lib/rivet/src/ast/Decl.ri
@@ -208,7 +208,7 @@ pub struct ImportedMod {
 }
 
 pub func filter_field_decl(decls: []Decl) -> []Decl {
-    mut fields := @dyn_array(Decl);
+    mut fields := []Decl();
     for decl in decls {
         if decl is .Field {
             fields.push(decl);

--- a/lib/rivet/src/ast/Expr.ri
+++ b/lib/rivet/src/ast/Expr.ri
@@ -102,6 +102,17 @@ pub enum Expr < traits.Stringable {
         pos: token.Pos;
         mut type: Type;
     },
+    ArrayCtor {
+        is_dyn: bool;
+        is_mut: bool;
+        mut elem_type: Type;
+        mut init_value: ?Expr;
+        mut cap_value: ?Expr;
+        mut len_value: ?Expr;
+        mut len_res: uint;
+        mut type: Type;
+        pos: token.Pos;
+    },
     ArrayLiteral {
         values: []mut Expr;
         is_dyn: bool;
@@ -312,6 +323,7 @@ pub enum Expr < traits.Stringable {
             .StringLiteral(string_lit) -> string_lit.pos,
             .EnumLiteral(enum_lit) -> enum_lit.pos,
             .TupleLiteral(tuple_lit) -> tuple_lit.pos,
+            .ArrayCtor(array_ctor) -> array_ctor.pos,
             .ArrayLiteral(array_lit) -> array_lit.pos,
             .Index(index) -> index.pos,
             .Selector(selector) -> selector.pos,
@@ -375,6 +387,37 @@ pub enum Expr < traits.Stringable {
                     }
                 }
                 sb.write_byte(b')');
+                sb.to_string()
+            },
+            .ArrayCtor(array_ctor) -> {
+                mut sb := strings.Builder.new(100);
+                sb.write_byte(b'[');
+                if !array_ctor.is_dyn {
+                    sb.write_string(array_ctor.len_value?.to_string());
+                }
+                sb.write_byte(b']');
+                if array_ctor.is_mut {
+                    sb.write_string("mut ");
+                }
+                sb.write_fmt("{}(", array_ctor.elem_type);
+                if array_ctor.is_dyn {
+                    if init_value := array_ctor.init_value {
+                        sb.write_fmt("init: {}", init_value);
+                        if array_ctor.cap_value !is none or array_ctor.len_value !is none {
+                            sb.write_string(", ");
+                        }
+                    }
+                    if cap_value := array_ctor.cap_value {
+                        sb.write_fmt("cap: {}", cap_value);
+                        if array_ctor.len_value !is none {
+                            sb.write_string(", ");
+                        }
+                    }
+                    if len_value := array_ctor.len_value {
+                        sb.write_fmt("len: {}", len_value);
+                    }
+                }
+                sb.write_string(")");
                 sb.to_string()
             },
             .ArrayLiteral(array_lit) -> {

--- a/lib/rivet/src/ast/Expr.ri
+++ b/lib/rivet/src/ast/Expr.ri
@@ -225,7 +225,6 @@ pub enum Expr < traits.Stringable {
     BuiltinCall {
         name: string;
         args: []CallArg;
-        dyn_array_is_mut: bool;
         pos: token.Pos;
         mut builtin: Builtin := .Invalid;
         mut type: Type;

--- a/lib/rivet/src/ast/Sym.ri
+++ b/lib/rivet/src/ast/Sym.ri
@@ -246,7 +246,7 @@ pub struct Module < Sym {
         if type_sym := self.scope.find(unique_name) {
             return @as(TypeSym, type_sym);
         }
-        mut fields := @dyn_array(Field);
+        mut fields := []Field();
         for i, type in types {
             fields.push(Field(name: i.to_string(), is_public: true, type: type));
         }

--- a/lib/rivet/src/ast/Table.ri
+++ b/lib/rivet/src/ast/Table.ri
@@ -353,7 +353,7 @@ pub struct Table {
                         types := if type_sym.info is .Tuple(tuple_lit) {
                             tuple_lit.types
                         } else {
-                            mut tmp := @dyn_array(Type);
+                            mut tmp := []Type();
                             for field in type_sym.full_fields() {
                                 tmp.push(field.type);
                             }
@@ -388,7 +388,7 @@ pub struct Table {
     }
 
     pub func filter_files(self, inputs: []string) -> []string {
-        mut new_inputs := @dyn_array(string, inputs.len);
+        mut new_inputs := []string(cap: inputs.len);
         for input in inputs {
             base_name_input := Path.base_name(input);
             if base_name_input.count(".") == 1 {
@@ -396,7 +396,7 @@ pub struct Table {
                 continue;
             }
             exts := base_name_input.substr(end: base_name_input.len - 3).split(".")[1..];
-            mut already_exts := @dyn_array(string, exts.len);
+            mut already_exts := []string(cap: exts.len);
             mut should_compile := false;
             for ext in exts {
                 if ext in already_exts {

--- a/lib/rivet/src/ast/Table.ri
+++ b/lib/rivet/src/ast/Table.ri
@@ -171,13 +171,6 @@ pub struct Table {
                 BuiltinArg("msg", type: self.string_t, is_optional: true)
             ]),
 
-            .Func("dyn_array", +[
-                BuiltinArg("type", is_any: true),
-                BuiltinArg("cap", type: self.uint_t, is_optional: true)
-            ], checks: +[
-                .ReturnTypeEqualToArgumentType(0)
-            ]),
-
             .Func("set_enum_ref_value", +[
                 BuiltinArg("enum_value", is_any: true, is_mut: true),
                 BuiltinArg("new_value", is_any: true)

--- a/lib/rivet/src/ast/Type.ri
+++ b/lib/rivet/src/ast/Type.ri
@@ -116,7 +116,7 @@ pub enum Type < traits.Stringable {
             .Result(result) -> .Result(result.inner.unalias() ?? result.inner),
             .Option(option) -> .Option(option.inner.unalias() ?? option.inner),
             .Tuple(tuple_data) -> {
-                unaliased_types := @dyn_array(mut Type, tuple_data.inners.len);
+                unaliased_types := []mut Type(cap: tuple_data.inners.len);
                 for i, tuple_type in tuple_data.inners {
                     unaliased_types[i] = tuple_type.unalias() ?? tuple_type;
                 }

--- a/lib/rivet/src/ast/TypeSym.ri
+++ b/lib/rivet/src/ast/TypeSym.ri
@@ -131,7 +131,7 @@ pub struct TypeSym < Sym {
         if !self.full_fields_.is_empty() {
             return self.full_fields_;
         }
-        mut fields := @dyn_array(Field);
+        mut fields := []Field();
         if self.info is .Trait(trait_info) {
             for mut b in trait_info.bases {
                 for bf in b.full_fields() {

--- a/lib/rivet/src/checker/builtin_call.ri
+++ b/lib/rivet/src/checker/builtin_call.ri
@@ -96,10 +96,6 @@ extend Checker {
             }
             match b_func.name {
                 "as" -> self.check_builtin_as(builtin_call),
-                "dyn_array" if builtin_call.args[0].expr is .Type(dyn_array_t) ->
-                    return_type = .Basic(self.table.universe.add_or_get_dyn_array(
-                        dyn_array_t, builtin_call.dyn_array_is_mut
-                    )),
                 else -> {}
             }
             return_type

--- a/lib/rivet/src/checker/check_trait_impl.ri
+++ b/lib/rivet/src/checker/check_trait_impl.ri
@@ -8,11 +8,11 @@ import ../report;
 
 extend Checker {
     func check_trait_impl(mut self, impltor: ast.TypeSym, trait_sym: ast.TypeSym, pos: token.Pos) {
-        mut impl_does_not_implemented := @dyn_array(string);
+        mut impl_does_not_implemented := []string();
         for sym in trait_sym.scope.syms {
             if sym is ast.Func(trait_func) {
                 if impl := impltor.find_func(trait_func.name); !trait_func.has_body {
-                    mut errors := @dyn_array(string);
+                    mut errors := []string();
                     if !impl.is_public {
                         errors.push("method `{}` should be public.".fmt(impl.name));
                     }

--- a/lib/rivet/src/checker/exprs.ri
+++ b/lib/rivet/src/checker/exprs.ri
@@ -86,6 +86,56 @@ extend Checker {
                 enum_lit.type
             },
             .TupleLiteral(mut tuple_lit) -> self.check_tuple_literal(tuple_lit),
+            .ArrayCtor(array_ctor) -> {
+                if mut init_value := array_ctor.init_value {
+                    init_t := self.check_expr(init_value);
+                    if !self.check_compatible_types(init_t, array_ctor.elem_type) {
+                        report.error(
+                            "argument `init` should have a value of type `{}`".fmt(
+                                array_ctor.elem_type
+                            ), init_value.position()
+                        );
+                    }
+                    if array_ctor.len_value is none {
+                        report.error(
+                            "`init` argument should be used together with `len` argument",
+                            init_value.position()
+                        );
+                    }
+                }
+                if mut len_value := array_ctor.len_value {
+                    len_t := self.check_expr(len_value);
+                    if !(len_t == self.table.uint_t or len_t == self.table.comptime_int_t) {
+                        report.error(
+                            "argument `len` should have a value of type `uint`",
+                            len_value.position()
+                        );
+                    }
+                }
+                if mut cap_value := array_ctor.cap_value {
+                    cap_t := self.check_expr(cap_value);
+                    if !(cap_t == self.table.uint_t or cap_t == self.table.comptime_int_t) {
+                        report.error(
+                            "argument `cap` should have a value of type `uint`",
+                            cap_value.position()
+                        );
+                    }
+                }
+                array_ctor.type = if array_ctor.is_dyn {
+                    .Basic(
+                        self.table.universe.add_or_get_dyn_array(
+                            array_ctor.elem_type, array_ctor.is_mut
+                        ), pos: array_ctor.pos
+                    )
+                } else {
+                    .Basic(
+                        self.table.universe.add_or_get_array(
+                            array_ctor.elem_type, array_ctor.len_res, array_ctor.is_mut
+                        ), pos: array_ctor.pos
+                    )
+                };
+                array_ctor.type
+            },
             .ArrayLiteral(mut array_lit) -> self.check_array_literal(array_lit),
             .Ident(ident) -> {
                 ident.type = if ident.name == "_" {

--- a/lib/rivet/src/checker/exprs.ri
+++ b/lib/rivet/src/checker/exprs.ri
@@ -277,12 +277,12 @@ extend Checker {
     func check_tuple_literal(mut self, mut tuple_lit: ast.Expr.TupleLiteral) -> ast.Type {
         old_expected_type := self.expected_type;
         mut has_expected_types := false;
-        mut expected_types := @dyn_array(ast.Type);
+        mut expected_types := []ast.Type();
         if expected_type_sym := self.expected_type.symbol(); expected_type_sym.info is .Tuple(tuple_info) {
             has_expected_types = tuple_lit.values.len == tuple_info.types.len;
             expected_types = tuple_info.types;
         }
-        mut types := @dyn_array(ast.Type);
+        mut types := []ast.Type();
         for i, mut value in tuple_lit.values {
             if has_expected_types {
                 self.expected_type = expected_types[i];

--- a/lib/rivet/src/checker/match_expr.ri
+++ b/lib/rivet/src/checker/match_expr.ri
@@ -41,7 +41,7 @@ extend Checker {
                 expr_type = guard_expr.vars[0].type;
                 expr_sym = expr_type.symbol()?;
             } else {
-                mut types := @dyn_array(mut ast.Type);
+                mut types := []mut ast.Type();
                 for var_ in guard_expr.vars {
                     types.push(var_.type);
                 }
@@ -166,7 +166,7 @@ extend Checker {
         // check that expressions are exhaustive, this is achieved either by putting
         // an `else` or when the `match` is on an enum by listing all variants.
         match_expr.is_exhaustive = true;
-        mut unhandled := @dyn_array(string);
+        mut unhandled := []string();
         if expr_type == self.table.bool_t and match_expr.branches.len == 1 {
             for v in ["true", "false"] {
                 if !branch_exprs.contains(v) {

--- a/lib/rivet/src/codegen/types.ri
+++ b/lib/rivet/src/codegen/types.ri
@@ -9,7 +9,7 @@ import ../depgraph;
 
 extend Codegen {
     func get_type_symbols(mut self, root: ast.Sym) -> []ast.TypeSym {
-        mut ts := @dyn_array(ast.TypeSym);
+        mut ts := []ast.TypeSym();
         for sym in root.scope.syms {
             if sym is ast.TypeSym(type_sym) and !(
                 type_sym.info is .DynArray or type_sym.info is .Alias
@@ -26,12 +26,12 @@ extend Codegen {
 
     func sort_type_symbols(mut self, tss: []ast.TypeSym) {
         mut dg := depgraph.DepGraph.new();
-        mut type_names := @dyn_array(string);
+        mut type_names := []string();
         for ts in tss {
             type_names.push(ts.qualname());
         }
         for ts in tss {
-            mut field_deps := @dyn_array(string);
+            mut field_deps := []string();
             match ts.info is {
                 .Array(array_info) -> {
                     dep := array_info.elem_type.to_qualstring();
@@ -115,7 +115,7 @@ extend Codegen {
                 is_void := result.inner.is_void();
                 name := "_R6Result".concat(self.mangle_type(result.inner));
                 if !self.generated_opt_res_types.contains(name) {
-                    mut fields := @dyn_array(mir.Field);
+                    mut fields := []mir.Field();
                     if !is_void {
                         fields.push(mir.Field("value", self.type_to_mir(result.inner)));
                     }
@@ -133,7 +133,7 @@ extend Codegen {
                     is_void := option.inner.is_void();
                     name := "_R6Option".concat(self.mangle_type(result.inner));
                     if !self.generated_opt_res_types.contains(name) {
-                        mut fields := @dyn_array(mir.Field);
+                        mut fields := []mir.Field();
                         if !is_void {
                             fields.push(mir.Field("value", self.type_to_mir(option.inner)));
                         }
@@ -166,7 +166,7 @@ extend Codegen {
                     }
                     match type_sym.info is {
                         .Func(func_info) -> {
-                            mut args := @dyn_array(mir.Type);
+                            mut args := []mir.Type();
                             for arg in func_info.args {
                                 args.push(self.type_to_mir(arg.type));
                             }

--- a/lib/rivet/src/depgraph/OrderedDepMap.ri
+++ b/lib/rivet/src/depgraph/OrderedDepMap.ri
@@ -55,7 +55,7 @@ pub struct OrderedDepMap {
     }
 
     pub func apply_diff(mut self, name: string, deps: []string) {
-        mut diff := @dyn_array(string);
+        mut diff := []string();
         deps_of_name := self.get(name);
         for dep in deps_of_name {
             if dep !in deps {

--- a/lib/rivet/src/depgraph/mod.ri
+++ b/lib/rivet/src/depgraph/mod.ri
@@ -19,7 +19,7 @@ pub struct DepGraph {
 
     #[inline]
     pub func new() -> Self {
-        return Self(true, @dyn_array(DepGraphNode, 1024));
+        return Self(true, []DepGraphNode(cap: 1024));
     }
 
     #[inline]
@@ -38,7 +38,7 @@ pub struct DepGraph {
         mut resolved := Self.new();
         while node_deps.size() != 0 {
             iterations += 1;
-            mut ready_set := @dyn_array(string);
+            mut ready_set := []string();
             for name in node_deps.keys {
                 deps := node_deps.get(name);
                 if deps.is_empty() {
@@ -83,7 +83,7 @@ pub struct DepGraph {
         }
         mut nn_names_it := nn.names.iterator();
         while k := nn_names_it.next() {
-            mut cycle_names := @dyn_array(string);
+            mut cycle_names := []string();
             if nn.is_cycle.contains(k.key) {
                 continue;
             }
@@ -113,7 +113,7 @@ struct NodeNames {
             return (true, new_already_seen);
         }
         new_already_seen.push(name);
-        deps := self.names.get(name) ?? @dyn_array(string);
+        deps := self.names.get(name) ?? []string();
         if deps.is_empty() {
             self.is_cycle.set(name, false);
             return (false, new_already_seen);

--- a/lib/rivet/src/fmt/mod.ri
+++ b/lib/rivet/src/fmt/mod.ri
@@ -103,7 +103,7 @@ pub struct Formatter {
         buffer.go_back(if i > 0 { i - 1 } else { buffer.len() - i - 1 });
         self.empty_line = false;
         mut line_len: uint := 0;
-        mut last_line_str := @dyn_array(uint8);
+        mut last_line_str := []uint8();
         i = if buffer.len() > 0 { buffer.len() - 1 } else { 0 };
         while i >= 0 : i -= 1 {
             ch := buffer.byte_at(i);
@@ -152,7 +152,7 @@ pub struct Formatter {
 }
 
 func reverse(buf: []uint8) -> []uint8 {
-    mut reversed := @dyn_array(uint8);
+    mut reversed := []uint8();
     mut i := buf.len - 1;
     while i >= 0 : i -= 1 {
         reversed.push(buf[i]);

--- a/lib/rivet/src/lib.ri
+++ b/lib/rivet/src/lib.ri
@@ -169,7 +169,7 @@ pub struct Compiler {
         mut name := "";
         mut full_name := "";
         mut abspath := "";
-        mut files := @dyn_array(string);
+        mut files := []string();
         is_super := pathx.starts_with("../");
         if pathx.starts_with("./") or is_super {
             self.vlog("    searching module in local path");
@@ -288,7 +288,7 @@ pub struct Compiler {
         }
         self.vlog("-----------------------------------------");
         source_files := self.table.source_files;
-        self.table.source_files = @dyn_array(ast.SourceFile, source_files.len);
+        self.table.source_files = []ast.SourceFile(cap: source_files.len);
         for node in g_resolved.nodes {
             for pf in source_files {
                 if pf.mod.name == node.name {
@@ -302,7 +302,7 @@ pub struct Compiler {
     func import_graph(self) -> depgraph.DepGraph {
         mut g := depgraph.DepGraph.new();
         for pf in self.table.source_files {
-            mut deps := @dyn_array(string);
+            mut deps := []string();
             if pf.mod.name !in ["c.ctypes", "c.libc", "c", "core"] {
                 deps.push("core");
             }

--- a/lib/rivet/src/parser/decls.ri
+++ b/lib/rivet/src/parser/decls.ri
@@ -10,7 +10,7 @@ import ../token;
 
 extend Parser {
     func parse_doc_comments(mut self) -> []ast.Comment {
-        mut comments := @dyn_array(ast.Comment);
+        mut comments := []ast.Comment();
         while self.tok.kind == .DocComment or (self.tok.kind == .Comment and comments.len > 0) {
             comments.push(self.parse_comment());
         }
@@ -25,7 +25,7 @@ extend Parser {
             }
             if self.accept(.Lbracket) {
                 while {
-                    mut args := @dyn_array(ast.AttributeArgument);
+                    mut args := []ast.AttributeArgument();
                     pos := self.tok.pos;
                     attribute_name := if self.accept(.KwUnsafe) {
                         "unsafe"
@@ -81,7 +81,7 @@ extend Parser {
     }
 
     func parse_decls(mut self) -> []ast.Decl {
-        mut decls := @dyn_array(ast.Decl);
+        mut decls := []ast.Decl();
         while self.tok.kind != .EndOfFile {
             decls.push(self.parse_decl());
         }
@@ -98,7 +98,7 @@ extend Parser {
         match {
             self.tok.kind == .Comment -> return .Comment(self.parse_comment()),
             self.accept(.KwImport) -> {
-                mut import_list := @dyn_array(ast.ImportListInfo);
+                mut import_list := []ast.ImportListInfo();
                 mut glob := false;
                 if self.accept(.Lbrace) {
                     while {
@@ -173,7 +173,7 @@ extend Parser {
                 self.inside_extern = true;
                 // extern function or var
                 abi := self.parse_abi();
-                mut decls := @dyn_array(ast.Decl);
+                mut decls := []ast.Decl();
                 if self.accept(.Lbrace) {
                     if is_public {
                         report.error("`extern` blocks cannot be declared public", pos);
@@ -249,7 +249,7 @@ extend Parser {
             },
             self.accept(.KwVar) -> {
                 // variable declarations
-                mut lefts := @dyn_array(ast.ObjectData);
+                mut lefts := []ast.ObjectData();
                 if self.accept(.Lparen) {
                     // multiple variables
                     while {
@@ -284,7 +284,7 @@ extend Parser {
                 old_inside_trait := self.inside_trait;
                 self.inside_trait = true;
                 name := self.parse_name();
-                mut bases := @dyn_array(mut ast.Type);
+                mut bases := []mut ast.Type();
                 if self.accept(.Lt) {
                     while {
                         bases.push(self.parse_type());
@@ -293,7 +293,7 @@ extend Parser {
                         }
                     }
                 }
-                mut decls := @dyn_array(ast.Decl);
+                mut decls := []ast.Decl();
                 self.expect(.Lbrace);
                 while !self.accept(.Rbrace) {
                     decls.push(self.parse_decl());
@@ -315,8 +315,8 @@ extend Parser {
                 self.inside_struct = true;
                 name := self.parse_name();
                 is_opaque := self.accept(.Semicolon);
-                mut bases := @dyn_array(mut ast.Type);
-                mut decls := @dyn_array(ast.Decl);
+                mut bases := []mut ast.Type();
+                mut decls := []ast.Decl();
                 if !is_opaque {
                     if self.accept(.Lt) {
                         while {
@@ -351,7 +351,7 @@ extend Parser {
                 } else {
                     self.table.comptime_int_t
                 };
-                mut bases := @dyn_array(mut ast.Type);
+                mut bases := []mut ast.Type();
                 if self.accept(.Lt) {
                     while {
                         bases.push(self.parse_type());
@@ -362,7 +362,7 @@ extend Parser {
                 }
                 self.expect(.Lbrace);
                 mut is_tagged := false;
-                mut variants := @dyn_array(ast.EnumVariantDecl);
+                mut variants := []ast.EnumVariantDecl();
                 while {
                     v_pos := self.tok.pos;
                     v_name := self.parse_name();
@@ -370,7 +370,7 @@ extend Parser {
                     mut has_value := false;
                     mut v_type := ast.Type.Void;
                     mut value := ast.Expr.Empty(self.tok.pos);
-                    mut variant_decls := @dyn_array(ast.Decl);
+                    mut variant_decls := []ast.Decl();
                     if self.accept(.Lbrace) {
                         has_type = true;
                         is_tagged = true;
@@ -402,7 +402,7 @@ extend Parser {
                         break;
                     }
                 }
-                mut decls := @dyn_array(ast.Decl);
+                mut decls := []ast.Decl();
                 if self.accept(.Semicolon) {
                     while self.tok.kind != .Rbrace {
                         decls.push(self.parse_decl());
@@ -445,7 +445,7 @@ extend Parser {
             },
             self.accept(.KwExtend) -> {
                 type := self.parse_type();
-                mut bases := @dyn_array(mut ast.Type);
+                mut bases := []mut ast.Type();
                 if self.accept(.Lt) {
                     while {
                         bases.push(self.parse_type());
@@ -455,7 +455,7 @@ extend Parser {
                     }
                 }
                 self.expect(.Lbrace);
-                mut decls := @dyn_array(ast.Decl);
+                mut decls := []ast.Decl();
                 while !self.accept(.Rbrace) {
                     decls.push(self.parse_decl());
                 }
@@ -480,7 +480,7 @@ extend Parser {
                 self.open_scope();
                 sc := self.scope;
                 sc.detached_from_parent = true;
-                mut stmts := @dyn_array(mut ast.Stmt);
+                mut stmts := []mut ast.Stmt();
                 self.expect(.Lbrace);
                 while !self.accept(.Rbrace) {
                     stmts.push(self.parse_stmt());
@@ -543,7 +543,7 @@ extend Parser {
         mut self_is_mut := false;
         mut self_is_ptr := false;
         mut self_pos := token.noPos;
-        mut args := @dyn_array(ast.Arg);
+        mut args := []ast.Arg();
         mut has_named_args := false;
         mut is_variadic := false;
 
@@ -619,7 +619,7 @@ extend Parser {
             }
         }
 
-        mut stmts := @dyn_array(mut ast.Stmt);
+        mut stmts := []mut ast.Stmt();
         mut has_body := true;
         if (self.inside_trait or self.inside_extern) and self.accept(.Semicolon) {
             has_body = false;

--- a/lib/rivet/src/parser/exprs.ri
+++ b/lib/rivet/src/parser/exprs.ri
@@ -226,7 +226,7 @@ extend Parser {
                     } else {
                         self.parse_name()
                     };
-                    mut args := @dyn_array(ast.CallArg);
+                    mut args := []ast.CallArg();
                     self.expect(.Lparen);
                     mut dyn_array_is_mut := false;
                     if name in ["dyn_array", "as", "size_of", "align_of"] {
@@ -311,7 +311,7 @@ extend Parser {
             },
             self.tok.kind in [.Lbracket, .Plus] -> {
                 mut is_dyn := self.accept(.Plus);
-                mut elems := @dyn_array(mut ast.Expr);
+                mut elems := []mut ast.Expr();
                 mut pos := self.tok.pos;
                 self.next();
                 if self.tok.kind != .Rbracket {
@@ -425,7 +425,7 @@ extend Parser {
                     and (expr is .Ident or expr is .Selector or expr is .Paren
                         or expr is .SelfTy or expr is .EnumLiteral) -> {
                     self.next();
-                    mut args := @dyn_array(ast.CallArg);
+                    mut args := []ast.CallArg();
                     mut spread_expr := ast.Expr.Empty(self.tok.pos);
                     mut has_spread_expr := false;
                     if self.tok.kind != .Rparen {
@@ -560,7 +560,7 @@ extend Parser {
     }
 
     func parse_if_expr(mut self) -> ast.Expr {
-        mut branches := @dyn_array(ast.IfBranch);
+        mut branches := []ast.IfBranch();
         mut has_else := false;
         mut pos := self.tok.pos;
         while self.tok.kind in [.KwIf, .KwElse] {
@@ -602,7 +602,7 @@ extend Parser {
 
     func parse_match_expr(mut self) -> ast.Expr {
         mut has_else := false;
-        mut branches := @dyn_array(ast.MatchBranch);
+        mut branches := []ast.MatchBranch();
         pos := self.prev_tok.pos;
         old_inside_match_header := self.inside_match_header;
         self.inside_match_header = true;
@@ -622,7 +622,7 @@ extend Parser {
         self.inside_match_header = old_inside_match_header;
         while {
             branch_pos := self.tok.pos;
-            mut cases := @dyn_array(mut ast.Expr);
+            mut cases := []mut ast.Expr();
             mut has_var := false;
             mut var_is_mut := false;
             mut var_name := "";
@@ -716,7 +716,7 @@ extend Parser {
         pos := self.tok.pos;
         is_unsafe := self.accept(.KwUnsafe);
         self.expect(.Lbrace);
-        mut stmts := @dyn_array(mut ast.Stmt);
+        mut stmts := []mut ast.Stmt();
         mut has_expr := false;
         mut expr := ast.Expr.Empty(self.tok.pos);
         while !self.accept(.Rbrace) {
@@ -736,7 +736,7 @@ extend Parser {
 
     func parse_guard_expr(mut self) -> ast.Expr {
         pos := self.tok.pos;
-        mut vars := @dyn_array(ast.ObjectData);
+        mut vars := []ast.ObjectData();
         if self.accept(.Lparen) {
             while {
                 vars.push(self.parse_var_decl(support_type: false));

--- a/lib/rivet/src/parser/exprs.ri
+++ b/lib/rivet/src/parser/exprs.ri
@@ -228,9 +228,7 @@ extend Parser {
                     };
                     mut args := []ast.CallArg();
                     self.expect(.Lparen);
-                    mut dyn_array_is_mut := false;
-                    if name in ["dyn_array", "as", "size_of", "align_of"] {
-                        dyn_array_is_mut = name == "dyn_array" and self.accept(.KwMut);
+                    if name in ["as", "size_of", "align_of"] {
                         arg_pos := self.tok.pos;
                         args.push(
                             ast.CallArg(
@@ -252,7 +250,7 @@ extend Parser {
                         }
                     }
                     self.expect(.Rparen);
-                    .BuiltinCall(name, args, dyn_array_is_mut, pos + self.prev_tok.pos)
+                    .BuiltinCall(name, args, pos + self.prev_tok.pos)
                 } else {
                     self.parse_ident(true) // builtin variable
                 }

--- a/lib/rivet/src/parser/exprs.ri
+++ b/lib/rivet/src/parser/exprs.ri
@@ -310,7 +310,7 @@ extend Parser {
                 }
             },
             self.tok.kind in [.Lbracket, .Plus] -> {
-                is_dyn := self.accept(.Plus);
+                mut is_dyn := self.accept(.Plus);
                 mut elems := @dyn_array(mut ast.Expr);
                 mut pos := self.tok.pos;
                 self.next();
@@ -322,9 +322,67 @@ extend Parser {
                         }
                     }
                 }
-                pos += self.tok.pos;
                 self.expect(.Rbracket);
-                .ArrayLiteral(elems, is_dyn, pos)
+                pos += self.prev_tok.pos;
+                if !is_dyn and (elems.len == 0 or elems.len == 1 and self.tok.kind !in [
+                    .Semicolon, .Comma, .Rbrace
+                ]) {
+                    // []T() or [SIZE]T()
+                    is_dyn = elems.len == 0;
+                    is_mut := self.accept(.KwMut);
+                    elem_type := self.parse_type();
+                    mut init_value: ?ast.Expr := none;
+                    mut cap_value: ?ast.Expr := none;
+                    mut len_value: ?ast.Expr := none;
+                    self.expect(.Lparen);
+                    while self.tok.kind != .Rparen {
+                        mut arg_pos := self.tok.pos;
+                        arg_name := self.parse_name();
+                        self.expect(.Colon);
+                        arg_value := self.parse_expr();
+                        arg_pos += self.prev_tok.pos;
+                        match arg_name {
+                            "init" -> if init_value is none {
+                                init_value = arg_value;
+                            } else {
+                                report.error("duplicate array constructor argument `init`", arg_pos);
+                                break;
+                            },
+                            "len" if is_dyn -> if len_value is none {
+                                len_value = arg_value;
+                            } else {
+                                report.error("duplicate array constructor argument `len`", arg_pos);
+                                break;
+                            },
+                            "cap" if is_dyn -> if cap_value is none {
+                                cap_value = arg_value;
+                            } else {
+                                report.error("duplicate array constructor argument `cap`", arg_pos);
+                                break;
+                            },
+                            else -> {
+                                report.error(
+                                    "unknown array constructor argument `{}`".fmt(arg_name),
+                                    arg_pos
+                                );
+                                break;
+                            }
+                        }
+                        if self.tok.kind != .Rparen {
+                            self.expect(.Comma);
+                        }
+                    }
+                    self.expect(.Rparen);
+                    pos += self.prev_tok.pos;
+                    if !is_dyn {
+                        len_value = elems[0];
+                    }
+                    .ArrayCtor(
+                        is_dyn, is_mut, elem_type, init_value, cap_value, len_value, pos: pos
+                    )
+                } else {
+                    .ArrayLiteral(elems, is_dyn, pos)
+                }
             },
             self.tok.kind == .Name -> if self.peek_tok.kind == .Char {
                 if self.tok.lit == "b" {

--- a/lib/rivet/src/parser/mod.ri
+++ b/lib/rivet/src/parser/mod.ri
@@ -39,7 +39,7 @@ pub struct Parser {
     pub func parse_module(mut self, mod_sym: ast.Module, files: []string) -> []ast.SourceFile {
         self.scope = mod_sym.scope;
         self.mod_sym = mod_sym;
-        mut source_files := @dyn_array(ast.SourceFile);
+        mut source_files := []ast.SourceFile();
         for file in files {
             source_files.push(self.parse_file(file));
         }
@@ -173,7 +173,7 @@ pub struct Parser {
     // - follow_up: comments directly below the previous token as long as there
     // - is no empty line.
     func eat_comments(mut self, same_line: bool := false, follow_up: bool := false) -> []ast.Comment {
-        mut comments := @dyn_array(ast.Comment);
+        mut comments := []ast.Comment();
         mut line := self.prev_tok.pos.line;
         while {
             if self.tok.kind != .Comment or (same_line and self.tok.pos.line > line)

--- a/lib/rivet/src/parser/stmts.ri
+++ b/lib/rivet/src/parser/stmts.ri
@@ -59,7 +59,7 @@ extend Parser {
                     index = self.parse_var_decl(support_mut: false, support_type: false);
                     self.expect(.Comma);
                 }
-                mut values := @dyn_array(ast.ObjectData);
+                mut values := []ast.ObjectData();
                 if self.accept(.Lparen) {
                     while {
                         values.push(
@@ -113,7 +113,7 @@ extend Parser {
                 and self.decl_operator_is_used() -> {
                 // variable declarations
                 mut pos := self.tok.pos;
-                mut lefts := @dyn_array(ast.ObjectData);
+                mut lefts := []ast.ObjectData();
                 if self.accept(.Lparen) {
                     // multiple variables
                     while {

--- a/lib/rivet/src/parser/types.ri
+++ b/lib/rivet/src/parser/types.ri
@@ -16,7 +16,7 @@ extend Parser {
                 // function types
                 self.expect(.KwFunc);
                 self.expect(.Lparen);
-                mut args := @dyn_array(ast.Arg);
+                mut args := []ast.Arg();
                 if self.tok.kind != .Rparen {
                     while {
                         arg_pos := self.tok.pos;
@@ -77,7 +77,7 @@ extend Parser {
             },
             self.accept(.Lparen) -> {
                 // tuples
-                mut inners := @dyn_array(mut ast.Type);
+                mut inners := []mut ast.Type();
                 while {
                     inners.push(self.parse_type());
                     if !self.accept(.Comma) {

--- a/lib/rivet/src/resolver/exprs.ri
+++ b/lib/rivet/src/resolver/exprs.ri
@@ -35,6 +35,32 @@ extend Resolver {
                     self.resolve_expr(value);
                 }
             },
+            .ArrayCtor(array_ctor) -> {
+                _ = self.resolve_type(array_ctor.elem_type);
+                if mut init_value := array_ctor.init_value {
+                    self.resolve_expr(init_value);
+                }
+                if mut len_value := array_ctor.len_value {
+                    self.resolve_expr(len_value);
+                    if !array_ctor.is_dyn {
+                        if len_res := self.eval_size(len_value) {
+                            if len_res <= 0 {
+                                report.error(
+                                    "array size cannot be zero or negative", len_value.position()
+                                );
+                            }
+                            array_ctor.len_res = @as(uint, len_res);
+                        } else {
+                            report.error(
+                                "cannot calculate array size in comptime", len_value.position()
+                            );
+                        }
+                    }
+                }
+                if mut cap_value := array_ctor.cap_value {
+                    self.resolve_expr(cap_value);
+                }
+            },
             .ArrayLiteral(array_lit) -> {
                 for mut value in array_lit.values {
                     self.resolve_expr(value);

--- a/lib/rivet/src/tokenizer/mod.ri
+++ b/lib/rivet/src/tokenizer/mod.ri
@@ -47,7 +47,7 @@ pub struct Tokenizer {
     }
 
     func init(mut self) {
-        self.all_tokens = @dyn_array(token.Token, self.text.len / 3);
+        self.all_tokens = []token.Token(cap: self.text.len / 3);
         self.tokenize_remaining_text();
     }
 
@@ -242,7 +242,7 @@ pub struct Tokenizer {
         if escapes_pos.is_empty() {
             return s;
         }
-        mut ss := @dyn_array(string, escapes_pos.len * 2 + 1);
+        mut ss := []string(cap: escapes_pos.len * 2 + 1);
         ss.push(s.substr(escapes_pos[escapes_pos.len - 1] - start));
         for i, pos in escapes_pos {
             idx := pos - start;
@@ -285,7 +285,7 @@ func decode_o_escapes(s: string, start: uint, escapes_pos: []uint) -> string {
     if escapes_pos.is_empty() {
         return s;
     }
-    mut ss := @dyn_array(string, escapes_pos.len);
+    mut ss := []string(cap: escapes_pos.len);
     // everything before the first escape code position
     ss.push(s.substr(escapes_pos[escapes_pos.len - 1] - start));
     for i, pos in escapes_pos {
@@ -315,7 +315,7 @@ func decode_unicode_escaped_rune(str: string) -> string {
     return if str.len == end_idx {
         segment
     } else {
-        mut ss := @dyn_array(string, 2);
+        mut ss := []string(cap: 2);
         ss.push(segment);
         ss.push(str.substr(end_idx));
         utils.join(ss, "")

--- a/lib/rivet/src/tokenizer/next.ri
+++ b/lib/rivet/src/tokenizer/next.ri
@@ -627,7 +627,7 @@ extend Tokenizer {
                     ch = decode_unicode_escaped_rune(ch);
                 } else {
                     // find escape sequence start positions
-                    mut escapes_pos := @dyn_array(uint);
+                    mut escapes_pos := []uint();
                     for i, v in ch.as_bytes() {
                         if v == BACKSLASH {
                             escapes_pos.push(i);
@@ -678,8 +678,8 @@ extend Tokenizer {
         if start_char == LF {
             self.inc_line_number();
         }
-        mut u_escapes_pos := @dyn_array(uint); // pos list of \uXXXX
-        mut h_escapes_pos := @dyn_array(uint); // pos list of \xXX
+        mut u_escapes_pos := []uin(); // pos list of \uXXXX
+        mut h_escapes_pos := []uin(); // pos list of \xXX
         while {
             self.pos += 1;
             if self.pos >= self.text.len {
@@ -742,9 +742,9 @@ extend Tokenizer {
             lit = self.text.substr(start, self.pos).clone();
             if !self.prefs.is_fmt {
                 mut segment_idx: uint := 0;
-                mut str_segments := @dyn_array(string);
+                mut str_segments := []string();
                 if u_escapes_pos.len + h_escapes_pos.len > 0 {
-                    mut all_pos := @dyn_array(uint, u_escapes_pos.len + h_escapes_pos.len);
+                    mut all_pos := []uint(cap: u_escapes_pos.len + h_escapes_pos.len);
                     for pos1 in u_escapes_pos {
                         all_pos.push(pos1);
                     }

--- a/lib/rivet/src/tokenizer/next.ri
+++ b/lib/rivet/src/tokenizer/next.ri
@@ -678,8 +678,8 @@ extend Tokenizer {
         if start_char == LF {
             self.inc_line_number();
         }
-        mut u_escapes_pos := []uin(); // pos list of \uXXXX
-        mut h_escapes_pos := []uin(); // pos list of \xXX
+        mut u_escapes_pos := []uint(); // pos list of \uXXXX
+        mut h_escapes_pos := []uint(); // pos list of \xXX
         while {
             self.pos += 1;
             if self.pos >= self.text.len {

--- a/lib/rivet/tests/tokenizer.ri
+++ b/lib/rivet/tests/tokenizer.ri
@@ -11,7 +11,7 @@ var prefs_ := prefs.Prefs();
 
 func tokenize(text: string) -> []token.Token {
     mut tokenizer_ := tokenizer.Tokenizer.new(text, prefs_, Table.new(prefs_));
-    mut tokens := @dyn_array(token.Token, text.len / 3);
+    mut tokens := []token.Token(cap: text.len / 3);
     mut token := tokenizer_.next();
     while {
         tokens.push(token);

--- a/lib/std/src/flag/mod.ri
+++ b/lib/std/src/flag/mod.ri
@@ -74,7 +74,7 @@ pub struct FlagParser {
     pub func new(args: []string) -> Self {
         original_args := args.clone();
         mut all_before_dashdash := args.clone();
-        mut all_after_dashdash := @dyn_array(string);
+        mut all_after_dashdash := []string();
         idx_dashdash := index_of(args, "--");
         if v := idx_dashdash {
             all_before_dashdash.trim(v);
@@ -406,8 +406,8 @@ pub struct FlagParser {
     /// - found arguments and corresponding values are removed from args list.
     func parse_value(mut self, long_hand: string, short_hand: uint8) -> []string {
         full := "--".concat(long_hand);
-        mut found_entries := @dyn_array(string);
-        mut to_delete := @dyn_array(uint);
+        mut found_entries := []string();
+        mut to_delete := []uint();
         mut should_skip_one := false;
         for i, arg in self.args {
             if should_skip_one {

--- a/lib/std/src/fs/Directory.c.ri
+++ b/lib/std/src/fs/Directory.c.ri
@@ -78,7 +78,7 @@ pub struct Directory {
         rpath := Path.resolve(path_)!;
         unsafe {
             if dir := libc.opendir(path_.ptr) {
-                mut res := @dyn_array(string, 15);
+                mut res := []string(cap: 15);
                 while ent := libc.readdir(dir) {
                     bptr: [&]uint8 := &ent.*.d_name[0];
                     if (bptr[0] == 0 or (bptr[0] == b'.' and bptr[1] == 0)

--- a/lib/std/src/process/mod.c.ri
+++ b/lib/std/src/process/mod.c.ri
@@ -56,7 +56,7 @@ pub func execute(cmd: string) -> !Result {
     unsafe {
         if f := libc.popen(pcmd.ptr, c"r") {
             fd := libc.fileno(f);
-            buf: [4096]mut uint8 := [];
+            buf := [4096]mut uint8();
             pbuf: [&]mut uint8 := &mut buf[0];
             mut output := Builder.new(1024);
             while {

--- a/lib/std/src/semver/range.ri
+++ b/lib/std/src/semver/range.ri
@@ -75,7 +75,7 @@ struct ComparatorSet {
                 "invalid format of comparator set for input '{}'".fmt(input)
             );
         }
-        mut comparators := @dyn_array(Comparator);
+        mut comparators := []Comparator();
         for raw_comp in raw_comparators {
             comparators.push(
                 Comparator.parse(raw_comp) ?? throw InvalidComparatorFormatError(
@@ -116,7 +116,7 @@ struct Range {
 
     func parse(input: string) -> ?Range {
         raw_comparator_sets := input.split(comparatorSetSep);
-        mut comparator_sets := @dyn_array(ComparatorSet);
+        mut comparator_sets := []ComparatorSet();
         for raw_comp_set in raw_comparator_sets {
             if can_expand(raw_comp_set) {
                 comparator_sets.push(ComparatorSet.expand(raw_comp_set) ?? return none);

--- a/lib/std/src/strings/mod.ri
+++ b/lib/std/src/strings/mod.ri
@@ -6,19 +6,10 @@ import core;
 
 pub alias Builder := core.StringBuilder;
 
-func fill_dyn_array(len: uint) -> []mut int32 {
-    mut vec := @dyn_array(mut int32, len);
-    mut i: uint := 0;
-    while i < len : i += 1 {
-        vec.push(@as(int32, i));
-    }
-    return vec;
-}
-
 /// Uses levenshtein distance algorithm to calculate the distance between
 /// two strings (lower is closer).
 pub func levenshtein_distance(a: string, b: string) -> int32 {
-    f := fill_dyn_array(b.len + 1);
+    f := []mut int32(init: 0, len: b.len + 1);
     for ca in a.as_bytes() {
         mut j: uint := 1;
         mut fj1 := f[0];

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -545,6 +545,42 @@ class TupleLiteral:
     def __str__(self):
         return self.__repr__()
 
+class ArrayCtor:
+    def __init__(self, is_dyn, is_mut, elem_type, init_value, cap_value, len_value, pos):
+        self.is_dyn = is_dyn
+        self.is_mut = is_mut
+        self.elem_type = elem_type
+        self.init_value = init_value
+        self.cap_value = cap_value
+        self.len_value = len_value
+        self.len_res = None
+        self.typ = None
+        self.pos = pos
+
+    def __repr__(self):
+        res = "["
+        if not self.is_dyn:
+            res += str(self.len_value)
+        res += "]"
+        if self.is_mut:
+            res += "mut "
+        res += f"{self.elem_type}("
+        if self.is_dyn:
+            if self.init_value:
+                res += f"init: {self.init_value}"
+                if self.cap_value or self.len_value:
+                    res += ", "
+            if self.cap_value:
+                res += f"cap: {self.cap_value}"
+                if self.self.len_value:
+                    res += ", "
+            if self.len_value:
+                res += f"len: {self.len_value}"
+        return res + ")"
+
+    def __str__(self):
+        return self.__repr__()
+
 class ArrayLiteral:
     def __init__(self, elems, is_dyn, pos):
         self.elems = elems

--- a/rivetc/src/ast.py
+++ b/rivetc/src/ast.py
@@ -793,7 +793,6 @@ class BuiltinCallExpr:
         self.name = name
         self.args = args
         self.pos = pos
-        self.dyn_array_is_mut = False
         self.typ = None
 
     def __repr__(self):

--- a/rivetc/src/checker.py
+++ b/rivetc/src/checker.py
@@ -436,6 +436,8 @@ class Checker:
                 init_t = self.check_expr(expr.init_value)
                 if not self.check_compatible_types(init_t, expr.elem_type):
                     report.error(f"argument `init` should have a value of type `{expr.elem_type}`", expr.init_value.pos)
+                if not expr.len_value:
+                    report.error("`init` argument should be used together with `len` argument", expr.init_value.pos)
             if expr.cap_value:
                 cap_t = self.check_expr(expr.cap_value)
                 if not (cap_t == self.comp.uint_t or cap_t == self.comp.comptime_int_t):

--- a/rivetc/src/checker.py
+++ b/rivetc/src/checker.py
@@ -1044,28 +1044,6 @@ class Checker:
             elif expr.name == "ignore_not_mutated_warn":
                 _ = self.check_expr(expr.args[0])
                 self.check_expr_is_mut(expr.args[0])
-            elif expr.name == "dyn_array":
-                if len(expr.args) in (1, 2):
-                    elem_t = expr.args[0].typ
-                    expr.typ = type.Type(
-                        self.comp.universe.add_or_get_dyn_array(
-                            elem_t, expr.dyn_array_is_mut
-                        )
-                    )
-                    if len(expr.args) == 2:
-                        arg1_t = self.check_expr(expr.args[1])
-                        try:
-                            self.check_types(arg1_t, self.comp.uint_t)
-                        except utils.CompilerError as e:
-                            report.error(e.args[0], expr.args[1].pos)
-                            report.note(
-                                "in second argument of builtin function `dyn_array`"
-                            )
-                else:
-                    report.error(
-                        f"expected 1 or 2 arguments, found {len(expr.args)}",
-                        expr.pos
-                    )
             elif expr.name == "as":
                 old_expected_type = self.expected_type
                 self.expected_type = expr.typ

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -765,13 +765,6 @@ class Codegen:
                 self.cur_func.store_ptr(
                     arg0, ir.Inst(ir.InstKind.LoadPtr, [arg1])
                 )
-            elif expr.name == "dyn_array":
-                typ_sym = expr.typ.symbol()
-                if len(expr.args) == 2:
-                    return self.empty_dyn_array(
-                        typ_sym, self.gen_expr(expr.args[1])
-                    )
-                return self.empty_dyn_array(typ_sym)
             elif expr.name == "as":
                 arg1 = expr.args[1]
                 arg1_is_voidptr = isinstance(

--- a/rivetc/src/parser.py
+++ b/rivetc/src/parser.py
@@ -804,11 +804,8 @@ class Parser:
                 self.expect(Kind.Lparen)
                 args = []
                 dyn_array_is_mut = False
-                if name in ("dyn_array", "as", "size_of", "align_of"):
+                if name in ("as", "size_of", "align_of"):
                     pos = self.tok.pos
-                    dyn_array_is_mut = name == "dyn_array" and self.accept(
-                        Kind.KwMut
-                    )
                     args.append(ast.TypeNode(self.parse_type(), pos))
                     if self.tok.kind != Kind.Rparen:
                         self.expect(Kind.Comma)
@@ -819,7 +816,6 @@ class Parser:
                             break
                 self.expect(Kind.Rparen)
                 expr = ast.BuiltinCallExpr(name, args, expr.pos)
-                expr.dyn_array_is_mut = dyn_array_is_mut
             else: # builtin variable
                 expr = self.parse_ident(True)
         elif self.tok.kind == Kind.Dot and self.peek_tok.kind == Kind.Name:

--- a/rivetc/src/parser.py
+++ b/rivetc/src/parser.py
@@ -881,9 +881,9 @@ class Parser:
                     if not self.accept(Kind.Comma):
                         break
             self.expect(Kind.Rbracket)
-            if len(elems) == 0 or (len(elems) == 1 and not is_dyn) and self.tok.kind not in (
+            if not is_dyn and (len(elems) == 0 or len(elems) == 1 and self.tok.kind not in (
                 Kind.Semicolon, Kind.Comma, Kind.Rbrace
-            ):
+            )):
                 # []T() or [SIZE]T()
                 is_dyn = len(elems) == 0
                 is_mut = self.accept(Kind.KwMut)
@@ -903,26 +903,26 @@ class Parser:
                             break
                         else:
                             init_value = arg_value
-                    elif arg_name == "cap" and is_dyn:
-                        if cap_value:
-                            report.error("duplicate array constructor argument `cap`", arg_pos)
-                            break
-                        else:
-                            cap_value = arg_value
                     elif arg_name == "len" and is_dyn:
                         if len_value:
                             report.error("duplicate array constructor argument `len`", arg_pos)
                             break
                         else:
                             len_value = arg_value
+                    elif arg_name == "cap" and is_dyn:
+                        if cap_value:
+                            report.error("duplicate array constructor argument `cap`", arg_pos)
+                            break
+                        else:
+                            cap_value = arg_value
                     else:
                         report.error(f"unknown array constructor argument `{arg_name}`", arg_pos)
                         break
                     if self.tok.kind != Kind.Rparen:
                         self.expect(Kind.Comma)
+                self.expect(Kind.Rparen)
                 if not is_dyn:
                     len_value = elems[0]
-                self.expect(Kind.Rparen)
                 expr = ast.ArrayCtor(is_dyn, is_mut, elem_type, init_value, cap_value, len_value, pos)
             else:
                 expr = ast.ArrayLiteral(elems, is_dyn, pos)

--- a/rivetc/src/parser.py
+++ b/rivetc/src/parser.py
@@ -881,7 +881,51 @@ class Parser:
                     if not self.accept(Kind.Comma):
                         break
             self.expect(Kind.Rbracket)
-            expr = ast.ArrayLiteral(elems, is_dyn, pos)
+            if len(elems) == 0 or (len(elems) == 1 and not is_dyn) and self.tok.kind not in (
+                Kind.Semicolon, Kind.Comma, Kind.Rbrace
+            ):
+                # []T() or [SIZE]T()
+                is_dyn = len(elems) == 0
+                is_mut = self.accept(Kind.KwMut)
+                elem_type = self.parse_type()
+                init_value = None
+                cap_value = None
+                len_value = None
+                self.expect(Kind.Lparen)
+                while self.tok.kind != Kind.Rparen:
+                    arg_pos = self.tok.pos
+                    arg_name = self.parse_name()
+                    self.expect(Kind.Colon)
+                    arg_value = self.parse_expr()
+                    if arg_name == "init":
+                        if init_value:
+                            report.error("duplicate array constructor argument `init`", arg_pos)
+                            break
+                        else:
+                            init_value = arg_value
+                    elif arg_name == "cap" and is_dyn:
+                        if cap_value:
+                            report.error("duplicate array constructor argument `cap`", arg_pos)
+                            break
+                        else:
+                            cap_value = arg_value
+                    elif arg_name == "len" and is_dyn:
+                        if len_value:
+                            report.error("duplicate array constructor argument `len`", arg_pos)
+                            break
+                        else:
+                            len_value = arg_value
+                    else:
+                        report.error(f"unknown array constructor argument `{arg_name}`", arg_pos)
+                        break
+                    if self.tok.kind != Kind.Rparen:
+                        self.expect(Kind.Comma)
+                if not is_dyn:
+                    len_value = elems[0]
+                self.expect(Kind.Rparen)
+                expr = ast.ArrayCtor(is_dyn, is_mut, elem_type, init_value, cap_value, len_value, pos)
+            else:
+                expr = ast.ArrayLiteral(elems, is_dyn, pos)
         elif self.tok.kind == Kind.Name:
             if self.peek_tok.kind == Kind.Char:
                 if self.tok.lit == "b":

--- a/rivetc/src/resolver.py
+++ b/rivetc/src/resolver.py
@@ -234,7 +234,7 @@ class Resolver:
             for e in expr.exprs:
                 self.resolve_expr(e)
         elif isinstance(expr, ast.ArrayCtor):
-            self.resolve_expr(expr.elem_type)
+            self.resolve_type(expr.elem_type)
             if expr.init_value:
                 self.resolve_expr(expr.init_value)
             if expr.cap_value:

--- a/rivetc/src/resolver.py
+++ b/rivetc/src/resolver.py
@@ -233,6 +233,16 @@ class Resolver:
         elif isinstance(expr, ast.TupleLiteral):
             for e in expr.exprs:
                 self.resolve_expr(e)
+        elif isinstance(expr, ast.ArrayCtor):
+            self.resolve_expr(expr.elem_type)
+            if expr.init_value:
+                self.resolve_expr(expr.init_value)
+            if expr.cap_value:
+                self.resolve_expr(expr.cap_value)
+            if expr.len_value:
+                self.resolve_expr(expr.len_value)
+                if not expr.is_dyn:
+                    expr.len_res = self.eval_size(expr.len_value)
         elif isinstance(expr, ast.ArrayLiteral):
             for e in expr.elems:
                 self.resolve_expr(e)

--- a/tests/invalid/invalid_array_ctor.out
+++ b/tests/invalid/invalid_array_ctor.out
@@ -1,0 +1,4 @@
+tests/invalid/invalid_array_ctor.ri:2:21: error: `init` argument should be used together with `len` argument
+    2 |     _ = []int(init: 5); // invalid
+      |                     ^
+rivet: error: could not compile module `invalid_array_ctor`, aborting due to previous error

--- a/tests/invalid/invalid_array_ctor.ri
+++ b/tests/invalid/invalid_array_ctor.ri
@@ -1,0 +1,3 @@
+func main() {
+    _ = []int(init: 5); // invalid
+}

--- a/tests/valid/src/array.ri
+++ b/tests/valid/src/array.ri
@@ -8,6 +8,11 @@ func new_array() -> [4]int32 {
     return [1, 2, 3, 4];
 }
 
+test "array constructor" {
+    lit := [5]int(init: 10);
+    @assert(lit == [10, 10, 10, 10, 10]);
+}
+
 test "array literal" {
     lit := [1, 2, 3, 4];
     @assert(lit == [1, 2, 3, 4]);

--- a/tests/valid/src/dynamic_array.ri
+++ b/tests/valid/src/dynamic_array.ri
@@ -9,14 +9,14 @@ test "dynamic array from fixed array" {
     @assert(dyn_array == dyn_array2);
 }
 
-test "`@dyn_array` builtin function" {
+test "dynamic array constructor" {
     {
-        mut da := @dyn_array(int32);
+        mut da := []int32();
         da.push(5);
         @assert(da[0] == 5);
     }
     {
-        mut da := @dyn_array(int32, 2);
+        mut da := []int32(cap: 2);
         da.push(10);
         @assert(da.cap == 2);
         @assert(da[0] == 10);


### PR DESCRIPTION
New syntax is added to create arrays and dynamic arrays. This new syntax allows you to define a value that will be used by default, as well as define the length and capacity of the array (if it is dynamic, of course).

The previous syntax was to use the builtin function `dyn_array`; with this change, this function is no longer necessary and is removed from the compiler entirely.
