### PR TITLE
refact(rivetc.codegen): generate tagged enums using `union`s in the C backend

### DIFF
--- a/lib/core/src/utils.ri
+++ b/lib/core/src/utils.ri
@@ -27,7 +27,7 @@ func tagged_enum_cast(expected_id: uint, got_id: uint) {
     if got_id != expected_id {
         // TODO: replace indexes with names
         console_ewriteln(
-            "runtime error: cannot cast tagged enum ID({}) to type ID({})", enum_info._id_, expected_id
+            "runtime error: cannot cast tagged enum ID({}) to type ID({})", got_id, expected_id
         );
         bt_print(2);
         process_exit(1);

--- a/lib/core/src/utils.ri
+++ b/lib/core/src/utils.ri
@@ -13,7 +13,7 @@ func enum_cast(ptr: rawptr, expected_id: uint) -> rawptr {
     if enum_info._id_ != expected_id {
         // TODO: replace indexes with names
         console_ewriteln(
-            "runtime error: enum cast: cannot cast ID({}) to ID({})", enum_info._id_, expected_id
+            "runtime error: cannot cast tagged enum ID({}) to type ID({})", enum_info._id_, expected_id
         );
         bt_print(2);
         process_exit(1);
@@ -21,11 +21,24 @@ func enum_cast(ptr: rawptr, expected_id: uint) -> rawptr {
     return enum_info.obj;
 }
 
+
+
+func tagged_enum_cast(expected_id: uint, got_id: uint) {
+    if got_id != expected_id {
+        // TODO: replace indexes with names
+        console_ewriteln(
+            "runtime error: cannot cast tagged enum ID({}) to type ID({})", enum_info._id_, expected_id
+        );
+        bt_print(2);
+        process_exit(1);
+    }
+}
+
 func trait_cast(got_obj: rawptr, got_id: uint, expected_id: uint) -> rawptr {
     if got_id != expected_id {
         // TODO: replace indexes with names
         console_ewriteln(
-            "runtime error: trait cast: cannot cast ID({}) to ID({})", got_id, expected_id
+            "runtime error: cannot cast trait ID({}) to type ID({})", got_id, expected_id
         );
         bt_print(2);
         process_exit(1);

--- a/lib/core/src/utils.ri
+++ b/lib/core/src/utils.ri
@@ -2,32 +2,11 @@
 // Use of this source code is governed by an MIT license that can
 // be found in the LICENSE file.
 
-struct EnumInfo {
-    _rc_: uint;
-    _id_: uint;
-    obj: rawptr;
-}
-
-func enum_cast(ptr: rawptr, expected_id: uint) -> rawptr {
-    enum_info := unsafe { @as(&EnumInfo, ptr) };
-    if enum_info._id_ != expected_id {
-        // TODO: replace indexes with names
-        console_ewriteln(
-            "runtime error: cannot cast tagged enum ID({}) to type ID({})", enum_info._id_, expected_id
-        );
-        bt_print(2);
-        process_exit(1);
-    }
-    return enum_info.obj;
-}
-
-
-
 func tagged_enum_cast(expected_id: uint, got_id: uint) {
     if got_id != expected_id {
         // TODO: replace indexes with names
         console_ewriteln(
-            "runtime error: cannot cast tagged enum ID({}) to type ID({})", got_id, expected_id
+            "runtime error: cannot cast tagged enum ID({}) to variant ID({})", got_id, expected_id
         );
         bt_print(2);
         process_exit(1);

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -3024,12 +3024,20 @@ class Codegen:
                 # TODO: in the self-hosted compiler calculate the enum value here
                 # not in register nor resolver.
                 if ts.info.is_tagged:
+                    mangled_name = cg_utils.mangle_symbol(ts)
+                    fields = []
+                    for v in ts.info.variants:
+                        if v.has_typ:
+                            typ_sym = v.typ.symbol()
+                            fields.append(ir.Field(f"v{typ_sym.id}", self.ir_type(v.typ)))
+                    union_name = mangled_name + "5Union"
+                    self.out_rir.unions.append(ir.Union(union_name, fields))
                     self.out_rir.structs.append(
                         ir.Struct(
-                            False, cg_utils.mangle_symbol(ts), [
+                            False, mangled_name, [
                                 ir.Field("_rc_", ir.UINT_T),
                                 ir.Field("_idx_", ir.UINT_T),
-                                ir.Field("obj", ir.VOID_PTR_T)
+                                ir.Field("obj", ir.Type(union_name))
                             ]
                         )
                     )

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -165,7 +165,7 @@ class Codegen:
                     argc,
                     ir.Inst(ir.InstKind.Cast,
                             [argv, ir.UINT8_T.ptr().ptr()]),
-                    ir.Inst(ir.InstKind.GetRef, [testRunner])
+                    ir.Inst(ir.InstKind.GetPtr, [testRunner])
                 ]
             )
         else:
@@ -605,7 +605,7 @@ class Codegen:
                     elif nr_level < nr_level_expected:
                         while nr_level < nr_level_expected:
                             res_expr = ir.Inst(
-                                ir.InstKind.GetRef, [res_expr],
+                                ir.InstKind.GetPtr, [res_expr],
                                 res_expr.typ.ptr()
                             )
                             nr_level += 1
@@ -623,7 +623,7 @@ class Codegen:
             ) if isinstance(res_expr.typ, ir.Pointer) else 0
             while nr_level < nr_level_expected:
                 res_expr = ir.Inst(
-                    ir.InstKind.GetRef, [res_expr], res_expr.typ.ptr()
+                    ir.InstKind.GetPtr, [res_expr], res_expr.typ.ptr()
                 )
                 nr_level += 1
 
@@ -640,25 +640,13 @@ class Codegen:
         ):
             tmp = self.cur_func.local_name()
             tmp_t = expected_typ
-            load_ptr = False
-            if not (
-                isinstance(expected_typ, ir.Pointer) and expected_typ.is_managed
-            ):
-                load_ptr = True
-                expected_typ = expected_typ.ptr(True)
-            value = ir.Inst(
-                ir.InstKind.Cast, [
-                    ir.Inst(
-                        ir.InstKind.Call, [
-                            ir.Name("_R4core9enum_castF"), res_expr,
-                            expr_sym.info.get_variant_by_type(expected_typ_
-                                                              ).value
-                        ]
-                    ), expected_typ
-                ]
-            )
-            if load_ptr:
-                value = ir.Inst(ir.InstKind.LoadPtr, [value])
+            variant_idx = expr_sym.info.get_variant_by_type(expected_typ_).value
+            self.cur_func.add_call("_R4core16tagged_enum_castF", [
+                ir.Selector(ir.UINT_T, res_expr, ir.Name("_idx_")),
+                variant_idx
+            ])
+            obj_f = ir.Selector(ir.Type(cg_utils.mangle_symbol(expr_sym)+"5Union"), res_expr, ir.Name("obj"))
+            value = ir.Selector(self.ir_type(expr.typ), obj_f, ir.Name(f"v{variant_idx}"))
             self.cur_func.inline_alloca(tmp_t, tmp, value)
             res_expr = ir.Ident(tmp_t, tmp)
 
@@ -817,25 +805,13 @@ class Codegen:
                 elif typ_sym.kind == TypeKind.Enum and typ_sym.info.is_tagged:
                     tmp = self.cur_func.local_name()
                     tmp_t = ir_typ
-                    load_ptr = False
-                    if not (
-                        isinstance(ir_typ, ir.Pointer) and ir_typ.is_managed
-                    ):
-                        load_ptr = True
-                        ir_typ = ir_typ.ptr(True)
-                    value = ir.Inst(
-                        ir.InstKind.Cast, [
-                            ir.Inst(
-                                ir.InstKind.Call, [
-                                    ir.Name("_R4core9enum_castF"), res,
-                                    typ_sym.info.get_variant_by_type(expr.typ
-                                                                     ).value
-                                ]
-                            ), ir_typ
-                        ]
-                    )
-                    if load_ptr:
-                        value = ir.Inst(ir.InstKind.LoadPtr, [value])
+                    variant_idx = typ_sym.info.get_variant_by_type(expr.typ).value
+                    self.cur_func.add_call("_R4core16tagged_enum_castF", [
+                        ir.Selector(ir.UINT_T, res, ir.Name("_idx_")),
+                        variant_idx
+                    ])
+                    obj_f = ir.Selector(ir.Type(cg_utils.mangle_symbol(typ_sym)+"5Union"), res, ir.Name("obj"))
+                    value = ir.Selector(self.ir_type(expr.typ), obj_f, ir.Name(f"v{variant_idx}"))
                     self.cur_func.inline_alloca(tmp_t, tmp, value)
                     return ir.Ident(tmp_t, tmp)
                 tmp = self.cur_func.local_name()
@@ -964,10 +940,10 @@ class Codegen:
                     right_operand = right
                     if not isinstance(expr_left_typ_ir, ir.Pointer):
                         left_operand = ir.Inst(
-                            ir.InstKind.GetRef, [left_operand]
+                            ir.InstKind.GetPtr, [left_operand]
                         )
                         right_operand = ir.Inst(
-                            ir.InstKind.GetRef, [right_operand]
+                            ir.InstKind.GetPtr, [right_operand]
                         )
                     self.cur_func.store(
                         left,
@@ -1227,7 +1203,7 @@ class Codegen:
                     if sym_rec_is_ref and not isinstance(
                         self_expr.typ, ir.Pointer
                     ):
-                        self_expr = ir.Inst(ir.InstKind.GetRef, [self_expr])
+                        self_expr = ir.Inst(ir.InstKind.GetPtr, [self_expr])
                     elif isinstance(
                         receiver.typ, type.Ptr
                     ) and not sym_rec_is_ref:
@@ -1252,7 +1228,7 @@ class Codegen:
                     if left_sym.kind == TypeKind.DynArray and expr.sym.name == "push":
                         if arg.typ.symbol().is_boxed():
                             arg_value = ir.Inst(
-                                ir.InstKind.GetRef, [arg_value],
+                                ir.InstKind.GetPtr, [arg_value],
                                 arg_value.typ.ptr()
                             )
                 args.append(arg_value)
@@ -1547,7 +1523,7 @@ class Codegen:
                     init_value = self.gen_expr_with_cast(
                         expr.elem_type, expr.init_value
                     )
-                    args.append(ir.Inst(ir.InstKind.GetRef, [init_value]))
+                    args.append(ir.Inst(ir.InstKind.GetPtr, [init_value]))
                 # element size
                 args.append(ir.IntLit(ir.UINT_T, str(size)))
                 # length
@@ -1582,7 +1558,7 @@ class Codegen:
                             ir.IntLit(
                                 ir.UINT_T, str(expr.typ.symbol().info.size)
                             ),
-                            ir.Inst(ir.InstKind.GetRef, [init_value])
+                            ir.Inst(ir.InstKind.GetPtr, [init_value])
                         ]
                     )
                 if custom_tmp:
@@ -1733,7 +1709,7 @@ class Codegen:
                 ) and right.kind == ir.InstKind.LoadPtr:
                     right = right.args[0]
                 else:
-                    right = ir.Inst(ir.InstKind.GetRef, [right])
+                    right = ir.Inst(ir.InstKind.GetPtr, [right])
                 self.cur_func.inline_alloca(self.ir_type(expr.typ), tmp, right)
                 return ir.Ident(self.ir_type(expr.typ), tmp)
 
@@ -1882,8 +1858,10 @@ class Codegen:
                         union_type = ir.Type(union_name)
                         obj_val = ir.Selector(union_type, left, ir.Name("obj"))
                         val = ir.Selector(
-                            ir.Type(self.ir_type(expr.typ)), obj_val, ir.Name(f"v{expr.var.typ.symbol().id}")
+                            ir.Type(self.ir_type(expr.typ)), obj_val, ir.Name(f"v{expr.right.variant_info.value}")
                         )
+                        if expr.var.is_mut and isinstance(var_t2, ir.Pointer):
+                            val = ir.Inst(ir.InstKind.GetPtr, [val], var_t2)
                     else:
                         val = ir.Inst(
                             ir.InstKind.Cast, [
@@ -2059,9 +2037,9 @@ class Codegen:
                                     cg_utils.mangle_symbol(typ_sym) +
                                     f"{len(op_method)}{op_method}M"
                                 ), left if sym_is_boxed else
-                                ir.Inst(ir.InstKind.GetRef, [left]),
+                                ir.Inst(ir.InstKind.GetPtr, [left]),
                                 right if sym_is_boxed else
-                                ir.Inst(ir.InstKind.GetRef, [right])
+                                ir.Inst(ir.InstKind.GetPtr, [right])
                             ]
                         )
                     )
@@ -2242,8 +2220,10 @@ class Codegen:
                                 )
                                 val = ir.Selector(
                                     self.ir_type(p.variant_info.typ),
-                                    obj_f, ir.Name(f"v{p.variant_info.typ.symbol().id}")
+                                    obj_f, ir.Name(f"v{p.variant_info.value}")
                                 )
+                                if b.var_is_mut and not isinstance(var_t, ir.Pointer):
+                                    val = ir.Inst(ir.InstKind.GetPtr, [val])
                             else:
                                 val = ir.Inst(
                                     ir.InstKind.Cast, [
@@ -2456,14 +2436,14 @@ class Codegen:
             if left_sym.kind == TypeKind.DynArray and assign_op == Kind.Assign:
                 rec = self.gen_expr_with_cast(expr.left_typ, expr.left)
                 if not isinstance(left_ir_typ, ir.Pointer):
-                    rec = ir.Inst(ir.InstKind.GetRef, [rec])
+                    rec = ir.Inst(ir.InstKind.GetPtr, [rec])
                 expr_right = self.gen_expr_with_cast(right.typ, right)
                 val_sym = right.typ.symbol()
                 self.cur_func.add_call(
                     "_R4core8DynArray3setM", [
                         rec,
                         self.gen_expr(expr.index),
-                        ir.Inst(ir.InstKind.GetRef, [expr_right])
+                        ir.Inst(ir.InstKind.GetPtr, [expr_right])
                     ]
                 )
                 self.inside_lhs_assign = old_inside_lhs_assign
@@ -2761,12 +2741,12 @@ class Codegen:
             value_f = ir.Selector(f_typ, value, ir.Name(f.name))
             if not isinstance(f_typ, ir.Pointer):
                 f_typ = f_typ.ptr(True)
-                value_f = ir.Inst(ir.InstKind.GetRef, [value_f], f_typ)
+                value_f = ir.Inst(ir.InstKind.GetPtr, [value_f], f_typ)
             self.cur_func.store(
                 ir.Selector(f_typ, tmp, ir.Name(f.name)), value_f
             )
         if not is_ptr:
-            value = ir.Inst(ir.InstKind.GetRef, [value])
+            value = ir.Inst(ir.InstKind.GetPtr, [value])
         value = value if is_ptr else ir.Inst(
             ir.InstKind.Call, [
                 ir.Name("_R4core7mem_dupF"), value,
@@ -2817,12 +2797,11 @@ class Codegen:
         if variant_info.has_typ and value and not isinstance(
             value, ast.EmptyExpr
         ):
-            variant_typ_sym = variant_info.typ.symbol()
             arg0 = self.gen_expr_with_cast(variant_info.typ, value)
             size, _ = self.comp.type_size(variant_info.typ)
             obj_f = ir.Selector(ir.Type(f"{cg_utils.mangle_symbol(enum_sym)}5Union"), tmp, ir.Name("obj"))
             self.cur_func.store(
-                ir.Selector(self.ir_type(variant_info.typ), obj_f, ir.Name(f"v{variant_typ_sym.id}")), 
+                ir.Selector(self.ir_type(variant_info.typ), obj_f, ir.Name(f"v{variant_info.value}")), 
                 arg0
             )
         return tmp
@@ -2837,14 +2816,13 @@ class Codegen:
                 cg_utils.mangle_symbol(enum_sym), enum_sym.id
             )
         variant_info = enum_sym.info.get_variant(variant_name)
-        variant_typ_sym = variant_info.typ.symbol()
         self.cur_func.store(
             ir.Selector(ir.UINT_T, tmp, ir.Name("_idx_")),
             ir.IntLit(ir.UINT_T, variant_info.value)
         )
         obj_f = ir.Selector(ir.Type(f"{cg_utils.mangle_symbol(enum_sym)}5Union"), tmp, ir.Name("obj"))
         self.cur_func.store(
-            ir.Selector(self.ir_type(variant_info.typ), obj_f, ir.Name(f"v{variant_typ_sym.id}")), value
+            ir.Selector(self.ir_type(variant_info.typ), obj_f, ir.Name(f"v{variant_info.value}")), value
         )
         return tmp
 
@@ -2867,7 +2845,7 @@ class Codegen:
         self.cur_func.add_call(
             "_R4core11ReturnTrace3addM", [
                 ir.Inst(
-                    ir.InstKind.GetRef, [
+                    ir.InstKind.GetPtr, [
                         ir.Ident(
                             ir.Type("_R4core11ReturnTrace"),
                             "_R4core11returnTrace"
@@ -2881,7 +2859,7 @@ class Codegen:
         self.cur_func.add_call(
             "_R4core11ReturnTrace5clearM", [
                 ir.Inst(
-                    ir.InstKind.GetRef, [
+                    ir.InstKind.GetPtr, [
                         ir.Ident(
                             ir.Type("_R4core11ReturnTrace"),
                             "_R4core11returnTrace"
@@ -3033,8 +3011,7 @@ class Codegen:
                     fields = []
                     for v in ts.info.variants:
                         if v.has_typ:
-                            typ_sym = v.typ.symbol()
-                            fields.append(ir.Field(f"v{typ_sym.id}", self.ir_type(v.typ)))
+                            fields.append(ir.Field(f"v{v.value}", self.ir_type(v.typ)))
                     union_name = mangled_name + "5Union"
                     self.out_rir.types.append(ir.Union(union_name, fields))
                     self.out_rir.types.append(
@@ -3186,6 +3163,10 @@ class Codegen:
                 for variant in ts.info.variants:
                     if variant.has_typ:
                         variant_sym = variant.typ.symbol()
+                        if variant_sym.kind != TypeKind.Struct:
+                            continue
+                        if variant_sym.is_boxed() or isinstance(variant.typ, type.Option):
+                            continue
                         dep = cg_utils.mangle_symbol(variant_sym)
                         if dep not in typ_names or dep in field_deps:
                             continue

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -1860,7 +1860,7 @@ class Codegen:
                         val = ir.Selector(
                             ir.Type(self.ir_type(expr.typ)), obj_val, ir.Name(f"v{expr.right.variant_info.value}")
                         )
-                        if expr.var.is_mut and isinstance(var_t2, ir.Pointer):
+                        if expr.var.is_mut and not isinstance(var_t2, ir.Pointer):
                             val = ir.Inst(ir.InstKind.GetPtr, [val], var_t2)
                     else:
                         val = ir.Inst(

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -717,7 +717,7 @@ class Codegen:
         elif isinstance(expr, ast.EnumLiteral):
             enum_sym = expr.typ.symbol()
             if expr.is_instance:
-                return self.boxed_enum_value(enum_sym, expr.value, None)
+                return self.tagged_enum_value(enum_sym, expr.value, None)
             return ir.IntLit(
                 self.ir_type(enum_sym.info.underlying_typ),
                 str(expr.variant_info.value)
@@ -1053,7 +1053,7 @@ class Codegen:
                             self.cur_func.store(
                                 ir.Selector(f_typ, tmp, ir.Name(f.name)), value
                             )
-                        return self.boxed_enum_variant_with_fields_value(
+                        return self.tagged_enum_variant_with_fields_value(
                             typ_sym, expr.left.value
                             if isinstance(expr.left, ast.EnumLiteral) else
                             expr.left.field_name, tmp, custom_tmp = custom_tmp
@@ -1063,14 +1063,14 @@ class Codegen:
                             x = expr.args[0].expr
                         else:
                             x = None
-                        return self.boxed_enum_value(
+                        return self.tagged_enum_value(
                             typ_sym, expr.left.value, x, custom_tmp = custom_tmp
                         )
                     if len(expr.args) > 0:
                         x = expr.args[0].expr
                     else:
                         x = None
-                    return self.boxed_enum_value(
+                    return self.tagged_enum_value(
                         typ_sym, expr.left.field_name, x,
                         custom_tmp = custom_tmp
                     )
@@ -1463,7 +1463,7 @@ class Codegen:
                     expr.left_sym, sym.Type
                 ) and expr.left_sym.kind == TypeKind.Enum:
                     if expr.left_sym.info.is_tagged:
-                        return self.boxed_enum_value(
+                        return self.tagged_enum_value(
                             expr.left_sym, expr.field_name, None,
                             custom_tmp = custom_tmp
                         )
@@ -2791,7 +2791,7 @@ class Codegen:
         )
         return tmp
 
-    def boxed_enum_value(
+    def tagged_enum_value(
         self, enum_sym, variant_name, value, custom_tmp = None
     ):
         if custom_tmp:
@@ -2826,7 +2826,7 @@ class Codegen:
         self.cur_func.store(ir.Selector(uint_t, tmp, ir.Name("obj")), value)
         return tmp
 
-    def boxed_enum_variant_with_fields_value(
+    def tagged_enum_variant_with_fields_value(
         self, enum_sym, variant_name, value, custom_tmp = None
     ):
         if custom_tmp:

--- a/rivetc/src/codegen/__init__.py
+++ b/rivetc/src/codegen/__init__.py
@@ -686,7 +686,7 @@ class Codegen:
             if expr.is_byte:
                 return ir.IntLit(
                     ir.UINT8_T,
-                    str(utils.bytestr(self.decode_escape(expr.lit)).buf[0])
+                    str(utils.bytestr(cg_utils.decode_escape(expr.lit)).buf[0])
                 )
             return ir.RuneLit(ir.RUNE_T, expr.lit)
         elif isinstance(expr, ast.IntegerLiteral):
@@ -3208,21 +3208,3 @@ class Codegen:
                 if ts.mangled_name == node.name:
                     types_sorted.append(ts)
         return types_sorted
-
-    def decode_escape(self, ch):
-        if ch.startswith("\\"):
-            code = ch[1:]
-            code_b = utils.bytestr(code).buf[0]
-            if code in ("\\", "'", '"'):
-                return chr(code_b)
-            elif code in ("a", "b", "f"):
-                return chr(code_b - 90)
-            elif code == "n":
-                return "\n"
-            elif code == "r":
-                return "\r"
-            elif code == "t":
-                return "\t"
-            elif code == "v":
-                return "\v"
-        return ch

--- a/rivetc/src/codegen/c.py
+++ b/rivetc/src/codegen/c.py
@@ -288,7 +288,7 @@ class CGen:
             self.write(" + ")
             self.gen_expr(inst.args[1])
             self.write(")")
-        elif inst.kind == InstKind.GetRef:
+        elif inst.kind == InstKind.GetPtr:
             arg0 = inst.args[0]
             if isinstance(arg0, (ir.Ident, ir.Selector, ir.ArrayLit)):
                 if isinstance(arg0, ir.ArrayLit):

--- a/rivetc/src/codegen/c_headers.py
+++ b/rivetc/src/codegen/c_headers.py
@@ -64,13 +64,13 @@ typedef uint32_t uint32;
 typedef uint64_t uint64;
 typedef ptrdiff_t ri_int;
 typedef size_t ri_uint;
-typedef ri_int comptime_int;
-
-typedef uint8 bool;
-typedef uint32 rune;
 
 typedef float float32;
 typedef double float64;
+
+typedef uint8 bool;
+typedef uint32 rune;
+typedef ri_int comptime_int;
 typedef float64 comptime_float;
 
 """

--- a/rivetc/src/codegen/cg_utils.py
+++ b/rivetc/src/codegen/cg_utils.py
@@ -5,8 +5,26 @@
 import os
 
 from ..sym import TypeKind
-from .. import ast, sym, type
+from .. import ast, sym, type, utils
 from ..token import OVERLOADABLE_OPERATORS_STR
+
+def decode_escape(ch):
+    if ch.startswith("\\"):
+        code = ch[1:]
+        code_b = utils.bytestr(code).buf[0]
+        if code in ("\\", "'", '"'):
+            return chr(code_b)
+        elif code in ("a", "b", "f"):
+            return chr(code_b - 90)
+        elif code == "n":
+            return "\n"
+        elif code == "r":
+            return "\r"
+        elif code == "t":
+            return "\t"
+        elif code == "v":
+            return "\v"
+    return ch
 
 def prefix_type(tt):
     prefix = ""

--- a/rivetc/src/codegen/ir.py
+++ b/rivetc/src/codegen/ir.py
@@ -528,7 +528,7 @@ class InstKind(Enum):
     StorePtr = auto_enum()
     LoadPtr = auto_enum()
     GetElementPtr = auto_enum()
-    GetRef = auto_enum()
+    GetPtr = auto_enum()
 
     Cast = auto_enum()
     Cmp = auto_enum()
@@ -570,7 +570,7 @@ class InstKind(Enum):
         elif self == InstKind.StorePtr: return "store_ptr"
         elif self == InstKind.LoadPtr: return "load_ptr"
         elif self == InstKind.GetElementPtr: return "get_element_ptr"
-        elif self == InstKind.GetRef: return "get_ref"
+        elif self == InstKind.GetPtr: return "get_ref"
         elif self == InstKind.Cast: return "cast"
         elif self == InstKind.Cmp: return "cmp"
         elif self == InstKind.DbgStmtLine: return "dbg_stmt_line"

--- a/rivetc/src/codegen/ir.py
+++ b/rivetc/src/codegen/ir.py
@@ -128,6 +128,7 @@ class Function:
 class RIRFile:
     def __init__(self, mod_name):
         self.mod_name = mod_name
+        self.unions = []
         self.structs = []
         self.externs = []
         self.globals = []
@@ -145,6 +146,11 @@ class RIRFile:
         sb.writeln(
             "// and is subject to change without notice. Knock yourself out."
         )
+        sb.writeln()
+        for i, u in enumerate(self.unions):
+            sb.writeln(str(u))
+            if i < len(self.unions) - 1:
+                sb.writeln()
         sb.writeln()
         for i, s in enumerate(self.structs):
             sb.writeln(str(s))
@@ -189,6 +195,23 @@ class VTable:
         sb.write("}")
         return str(sb)
 
+class Union:
+    def __init__(self, name, fields):
+        self.name = name
+        self.fields = fields
+
+    def __str__(self):
+        sb = utils.Builder()
+        sb.writeln(f'union {self.name} {{')
+        for i, f in enumerate(self.fields):
+            sb.write(f'  {f.name}: {f.typ}')
+            if i < len(self.fields) - 1:
+                sb.writeln(",")
+            else:
+                sb.writeln()
+        sb.write("}")
+        return str(sb)
+
 class Struct:
     def __init__(self, is_opaque, name, fields):
         self.is_opaque = is_opaque
@@ -198,9 +221,9 @@ class Struct:
     def __str__(self):
         sb = utils.Builder()
         if self.is_opaque:
-            sb.write(f'type {self.name} opaque')
+            sb.write(f'struct {self.name} opaque')
         else:
-            sb.writeln(f'type {self.name} {{')
+            sb.writeln(f'struct {self.name} {{')
             for i, f in enumerate(self.fields):
                 sb.write(f'  {f.name}: {f.typ}')
                 if i < len(self.fields) - 1:

--- a/rivetc/src/codegen/ir.py
+++ b/rivetc/src/codegen/ir.py
@@ -128,8 +128,7 @@ class Function:
 class RIRFile:
     def __init__(self, mod_name):
         self.mod_name = mod_name
-        self.unions = []
-        self.structs = []
+        self.types = []
         self.externs = []
         self.globals = []
         self.decls = []
@@ -147,14 +146,9 @@ class RIRFile:
             "// and is subject to change without notice. Knock yourself out."
         )
         sb.writeln()
-        for i, u in enumerate(self.unions):
-            sb.writeln(str(u))
-            if i < len(self.unions) - 1:
-                sb.writeln()
-        sb.writeln()
-        for i, s in enumerate(self.structs):
-            sb.writeln(str(s))
-            if i < len(self.structs) - 1:
+        for i, t in enumerate(self.types):
+            sb.writeln(str(t))
+            if i < len(self.types) - 1:
                 sb.writeln()
         sb.writeln()
         for i, e in enumerate(self.externs):


### PR DESCRIPTION
Previously `rawptr` and `mem.dup()` were used to create values ​​from tagged enums, now this is no longer required, and instead a `union` is used.